### PR TITLE
Many changes in the HangarAPI - v2.0.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 invokerPackage: Aternos\HangarApi
-artifactVersion: 1.0.0
+artifactVersion: 2.0.0
 generatorName: php
 outputDir: .
 sourceFolder: src

--- a/lib/Api/PagesApi.php
+++ b/lib/Api/PagesApi.php
@@ -136,7 +136,6 @@ class PagesApi
      *
      * Edits the main page of a project
      *
-     * @param  string $author The author of the project to change the page for (required)
      * @param  string $slug The slug of the project to change the page for (required)
      * @param  \Aternos\HangarApi\Model\StringContent $string_content string_content (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['editMainPage'] to see the possible values for this operation
@@ -145,9 +144,9 @@ class PagesApi
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function editMainPage($author, $slug, $string_content, string $contentType = self::contentTypes['editMainPage'][0])
+    public function editMainPage($slug, $string_content, string $contentType = self::contentTypes['editMainPage'][0])
     {
-        $this->editMainPageWithHttpInfo($author, $slug, $string_content, $contentType);
+        $this->editMainPageWithHttpInfo($slug, $string_content, $contentType);
     }
 
     /**
@@ -155,7 +154,6 @@ class PagesApi
      *
      * Edits the main page of a project
      *
-     * @param  string $author The author of the project to change the page for (required)
      * @param  string $slug The slug of the project to change the page for (required)
      * @param  \Aternos\HangarApi\Model\StringContent $string_content (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['editMainPage'] to see the possible values for this operation
@@ -164,9 +162,9 @@ class PagesApi
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function editMainPageWithHttpInfo($author, $slug, $string_content, string $contentType = self::contentTypes['editMainPage'][0])
+    public function editMainPageWithHttpInfo($slug, $string_content, string $contentType = self::contentTypes['editMainPage'][0])
     {
-        $request = $this->editMainPageRequest($author, $slug, $string_content, $contentType);
+        $request = $this->editMainPageRequest($slug, $string_content, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -217,7 +215,6 @@ class PagesApi
      *
      * Edits the main page of a project
      *
-     * @param  string $author The author of the project to change the page for (required)
      * @param  string $slug The slug of the project to change the page for (required)
      * @param  \Aternos\HangarApi\Model\StringContent $string_content (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['editMainPage'] to see the possible values for this operation
@@ -225,9 +222,9 @@ class PagesApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function editMainPageAsync($author, $slug, $string_content, string $contentType = self::contentTypes['editMainPage'][0])
+    public function editMainPageAsync($slug, $string_content, string $contentType = self::contentTypes['editMainPage'][0])
     {
-        return $this->editMainPageAsyncWithHttpInfo($author, $slug, $string_content, $contentType)
+        return $this->editMainPageAsyncWithHttpInfo($slug, $string_content, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -240,7 +237,6 @@ class PagesApi
      *
      * Edits the main page of a project
      *
-     * @param  string $author The author of the project to change the page for (required)
      * @param  string $slug The slug of the project to change the page for (required)
      * @param  \Aternos\HangarApi\Model\StringContent $string_content (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['editMainPage'] to see the possible values for this operation
@@ -248,10 +244,10 @@ class PagesApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function editMainPageAsyncWithHttpInfo($author, $slug, $string_content, string $contentType = self::contentTypes['editMainPage'][0])
+    public function editMainPageAsyncWithHttpInfo($slug, $string_content, string $contentType = self::contentTypes['editMainPage'][0])
     {
         $returnType = '';
-        $request = $this->editMainPageRequest($author, $slug, $string_content, $contentType);
+        $request = $this->editMainPageRequest($slug, $string_content, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -279,7 +275,6 @@ class PagesApi
     /**
      * Create request for operation 'editMainPage'
      *
-     * @param  string $author The author of the project to change the page for (required)
      * @param  string $slug The slug of the project to change the page for (required)
      * @param  \Aternos\HangarApi\Model\StringContent $string_content (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['editMainPage'] to see the possible values for this operation
@@ -287,15 +282,8 @@ class PagesApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function editMainPageRequest($author, $slug, $string_content, string $contentType = self::contentTypes['editMainPage'][0])
+    public function editMainPageRequest($slug, $string_content, string $contentType = self::contentTypes['editMainPage'][0])
     {
-
-        // verify the required parameter 'author' is set
-        if ($author === null || (is_array($author) && count($author) === 0)) {
-            throw new \InvalidArgumentException(
-                'Missing the required parameter $author when calling editMainPage'
-            );
-        }
 
         // verify the required parameter 'slug' is set
         if ($slug === null || (is_array($slug) && count($slug) === 0)) {
@@ -312,7 +300,7 @@ class PagesApi
         }
 
 
-        $resourcePath = '/api/v1/pages/editmain/{author}/{slug}';
+        $resourcePath = '/api/v1/pages/editmain/{slug}';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -321,14 +309,6 @@ class PagesApi
 
 
 
-        // path params
-        if ($author !== null) {
-            $resourcePath = str_replace(
-                '{' . 'author' . '}',
-                ObjectSerializer::toPathValue($author),
-                $resourcePath
-            );
-        }
         // path params
         if ($slug !== null) {
             $resourcePath = str_replace(
@@ -408,7 +388,6 @@ class PagesApi
      *
      * Edits a page of a project
      *
-     * @param  string $author The author of the project to change the page for (required)
      * @param  string $slug The slug of the project to change the page for (required)
      * @param  \Aternos\HangarApi\Model\PageEditForm $page_edit_form page_edit_form (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['editPage'] to see the possible values for this operation
@@ -417,9 +396,9 @@ class PagesApi
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function editPage($author, $slug, $page_edit_form, string $contentType = self::contentTypes['editPage'][0])
+    public function editPage($slug, $page_edit_form, string $contentType = self::contentTypes['editPage'][0])
     {
-        $this->editPageWithHttpInfo($author, $slug, $page_edit_form, $contentType);
+        $this->editPageWithHttpInfo($slug, $page_edit_form, $contentType);
     }
 
     /**
@@ -427,7 +406,6 @@ class PagesApi
      *
      * Edits a page of a project
      *
-     * @param  string $author The author of the project to change the page for (required)
      * @param  string $slug The slug of the project to change the page for (required)
      * @param  \Aternos\HangarApi\Model\PageEditForm $page_edit_form (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['editPage'] to see the possible values for this operation
@@ -436,9 +414,9 @@ class PagesApi
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function editPageWithHttpInfo($author, $slug, $page_edit_form, string $contentType = self::contentTypes['editPage'][0])
+    public function editPageWithHttpInfo($slug, $page_edit_form, string $contentType = self::contentTypes['editPage'][0])
     {
-        $request = $this->editPageRequest($author, $slug, $page_edit_form, $contentType);
+        $request = $this->editPageRequest($slug, $page_edit_form, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -489,7 +467,6 @@ class PagesApi
      *
      * Edits a page of a project
      *
-     * @param  string $author The author of the project to change the page for (required)
      * @param  string $slug The slug of the project to change the page for (required)
      * @param  \Aternos\HangarApi\Model\PageEditForm $page_edit_form (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['editPage'] to see the possible values for this operation
@@ -497,9 +474,9 @@ class PagesApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function editPageAsync($author, $slug, $page_edit_form, string $contentType = self::contentTypes['editPage'][0])
+    public function editPageAsync($slug, $page_edit_form, string $contentType = self::contentTypes['editPage'][0])
     {
-        return $this->editPageAsyncWithHttpInfo($author, $slug, $page_edit_form, $contentType)
+        return $this->editPageAsyncWithHttpInfo($slug, $page_edit_form, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -512,7 +489,6 @@ class PagesApi
      *
      * Edits a page of a project
      *
-     * @param  string $author The author of the project to change the page for (required)
      * @param  string $slug The slug of the project to change the page for (required)
      * @param  \Aternos\HangarApi\Model\PageEditForm $page_edit_form (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['editPage'] to see the possible values for this operation
@@ -520,10 +496,10 @@ class PagesApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function editPageAsyncWithHttpInfo($author, $slug, $page_edit_form, string $contentType = self::contentTypes['editPage'][0])
+    public function editPageAsyncWithHttpInfo($slug, $page_edit_form, string $contentType = self::contentTypes['editPage'][0])
     {
         $returnType = '';
-        $request = $this->editPageRequest($author, $slug, $page_edit_form, $contentType);
+        $request = $this->editPageRequest($slug, $page_edit_form, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -551,7 +527,6 @@ class PagesApi
     /**
      * Create request for operation 'editPage'
      *
-     * @param  string $author The author of the project to change the page for (required)
      * @param  string $slug The slug of the project to change the page for (required)
      * @param  \Aternos\HangarApi\Model\PageEditForm $page_edit_form (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['editPage'] to see the possible values for this operation
@@ -559,15 +534,8 @@ class PagesApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function editPageRequest($author, $slug, $page_edit_form, string $contentType = self::contentTypes['editPage'][0])
+    public function editPageRequest($slug, $page_edit_form, string $contentType = self::contentTypes['editPage'][0])
     {
-
-        // verify the required parameter 'author' is set
-        if ($author === null || (is_array($author) && count($author) === 0)) {
-            throw new \InvalidArgumentException(
-                'Missing the required parameter $author when calling editPage'
-            );
-        }
 
         // verify the required parameter 'slug' is set
         if ($slug === null || (is_array($slug) && count($slug) === 0)) {
@@ -584,7 +552,7 @@ class PagesApi
         }
 
 
-        $resourcePath = '/api/v1/pages/edit/{author}/{slug}';
+        $resourcePath = '/api/v1/pages/edit/{slug}';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -593,14 +561,6 @@ class PagesApi
 
 
 
-        // path params
-        if ($author !== null) {
-            $resourcePath = str_replace(
-                '{' . 'author' . '}',
-                ObjectSerializer::toPathValue($author),
-                $resourcePath
-            );
-        }
         // path params
         if ($slug !== null) {
             $resourcePath = str_replace(
@@ -680,7 +640,6 @@ class PagesApi
      *
      * Returns the main page of a project
      *
-     * @param  string $author The author of the project to return the page for (required)
      * @param  string $slug The slug of the project to return the page for (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getMainPage'] to see the possible values for this operation
      *
@@ -688,9 +647,9 @@ class PagesApi
      * @throws \InvalidArgumentException
      * @return string|string|string
      */
-    public function getMainPage($author, $slug, string $contentType = self::contentTypes['getMainPage'][0])
+    public function getMainPage($slug, string $contentType = self::contentTypes['getMainPage'][0])
     {
-        list($response) = $this->getMainPageWithHttpInfo($author, $slug, $contentType);
+        list($response) = $this->getMainPageWithHttpInfo($slug, $contentType);
         return $response;
     }
 
@@ -699,7 +658,6 @@ class PagesApi
      *
      * Returns the main page of a project
      *
-     * @param  string $author The author of the project to return the page for (required)
      * @param  string $slug The slug of the project to return the page for (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getMainPage'] to see the possible values for this operation
      *
@@ -707,9 +665,9 @@ class PagesApi
      * @throws \InvalidArgumentException
      * @return array of string|string|string, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getMainPageWithHttpInfo($author, $slug, string $contentType = self::contentTypes['getMainPage'][0])
+    public function getMainPageWithHttpInfo($slug, string $contentType = self::contentTypes['getMainPage'][0])
     {
-        $request = $this->getMainPageRequest($author, $slug, $contentType);
+        $request = $this->getMainPageRequest($slug, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -846,16 +804,15 @@ class PagesApi
      *
      * Returns the main page of a project
      *
-     * @param  string $author The author of the project to return the page for (required)
      * @param  string $slug The slug of the project to return the page for (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getMainPage'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getMainPageAsync($author, $slug, string $contentType = self::contentTypes['getMainPage'][0])
+    public function getMainPageAsync($slug, string $contentType = self::contentTypes['getMainPage'][0])
     {
-        return $this->getMainPageAsyncWithHttpInfo($author, $slug, $contentType)
+        return $this->getMainPageAsyncWithHttpInfo($slug, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -868,17 +825,16 @@ class PagesApi
      *
      * Returns the main page of a project
      *
-     * @param  string $author The author of the project to return the page for (required)
      * @param  string $slug The slug of the project to return the page for (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getMainPage'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getMainPageAsyncWithHttpInfo($author, $slug, string $contentType = self::contentTypes['getMainPage'][0])
+    public function getMainPageAsyncWithHttpInfo($slug, string $contentType = self::contentTypes['getMainPage'][0])
     {
         $returnType = 'string';
-        $request = $this->getMainPageRequest($author, $slug, $contentType);
+        $request = $this->getMainPageRequest($slug, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -919,22 +875,14 @@ class PagesApi
     /**
      * Create request for operation 'getMainPage'
      *
-     * @param  string $author The author of the project to return the page for (required)
      * @param  string $slug The slug of the project to return the page for (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getMainPage'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getMainPageRequest($author, $slug, string $contentType = self::contentTypes['getMainPage'][0])
+    public function getMainPageRequest($slug, string $contentType = self::contentTypes['getMainPage'][0])
     {
-
-        // verify the required parameter 'author' is set
-        if ($author === null || (is_array($author) && count($author) === 0)) {
-            throw new \InvalidArgumentException(
-                'Missing the required parameter $author when calling getMainPage'
-            );
-        }
 
         // verify the required parameter 'slug' is set
         if ($slug === null || (is_array($slug) && count($slug) === 0)) {
@@ -944,7 +892,7 @@ class PagesApi
         }
 
 
-        $resourcePath = '/api/v1/pages/main/{author}/{slug}';
+        $resourcePath = '/api/v1/pages/main/{slug}';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -953,14 +901,6 @@ class PagesApi
 
 
 
-        // path params
-        if ($author !== null) {
-            $resourcePath = str_replace(
-                '{' . 'author' . '}',
-                ObjectSerializer::toPathValue($author),
-                $resourcePath
-            );
-        }
         // path params
         if ($slug !== null) {
             $resourcePath = str_replace(
@@ -1029,7 +969,6 @@ class PagesApi
      *
      * Returns a page of a project
      *
-     * @param  string $author The author of the project to return the page for (required)
      * @param  string $slug The slug of the project to return the page for (required)
      * @param  string $path The path of the page (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getPage'] to see the possible values for this operation
@@ -1038,9 +977,9 @@ class PagesApi
      * @throws \InvalidArgumentException
      * @return string|string|string
      */
-    public function getPage($author, $slug, $path, string $contentType = self::contentTypes['getPage'][0])
+    public function getPage($slug, $path, string $contentType = self::contentTypes['getPage'][0])
     {
-        list($response) = $this->getPageWithHttpInfo($author, $slug, $path, $contentType);
+        list($response) = $this->getPageWithHttpInfo($slug, $path, $contentType);
         return $response;
     }
 
@@ -1049,7 +988,6 @@ class PagesApi
      *
      * Returns a page of a project
      *
-     * @param  string $author The author of the project to return the page for (required)
      * @param  string $slug The slug of the project to return the page for (required)
      * @param  string $path The path of the page (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getPage'] to see the possible values for this operation
@@ -1058,9 +996,9 @@ class PagesApi
      * @throws \InvalidArgumentException
      * @return array of string|string|string, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getPageWithHttpInfo($author, $slug, $path, string $contentType = self::contentTypes['getPage'][0])
+    public function getPageWithHttpInfo($slug, $path, string $contentType = self::contentTypes['getPage'][0])
     {
-        $request = $this->getPageRequest($author, $slug, $path, $contentType);
+        $request = $this->getPageRequest($slug, $path, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1197,7 +1135,6 @@ class PagesApi
      *
      * Returns a page of a project
      *
-     * @param  string $author The author of the project to return the page for (required)
      * @param  string $slug The slug of the project to return the page for (required)
      * @param  string $path The path of the page (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getPage'] to see the possible values for this operation
@@ -1205,9 +1142,9 @@ class PagesApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getPageAsync($author, $slug, $path, string $contentType = self::contentTypes['getPage'][0])
+    public function getPageAsync($slug, $path, string $contentType = self::contentTypes['getPage'][0])
     {
-        return $this->getPageAsyncWithHttpInfo($author, $slug, $path, $contentType)
+        return $this->getPageAsyncWithHttpInfo($slug, $path, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1220,7 +1157,6 @@ class PagesApi
      *
      * Returns a page of a project
      *
-     * @param  string $author The author of the project to return the page for (required)
      * @param  string $slug The slug of the project to return the page for (required)
      * @param  string $path The path of the page (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getPage'] to see the possible values for this operation
@@ -1228,10 +1164,10 @@ class PagesApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getPageAsyncWithHttpInfo($author, $slug, $path, string $contentType = self::contentTypes['getPage'][0])
+    public function getPageAsyncWithHttpInfo($slug, $path, string $contentType = self::contentTypes['getPage'][0])
     {
         $returnType = 'string';
-        $request = $this->getPageRequest($author, $slug, $path, $contentType);
+        $request = $this->getPageRequest($slug, $path, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1272,7 +1208,6 @@ class PagesApi
     /**
      * Create request for operation 'getPage'
      *
-     * @param  string $author The author of the project to return the page for (required)
      * @param  string $slug The slug of the project to return the page for (required)
      * @param  string $path The path of the page (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getPage'] to see the possible values for this operation
@@ -1280,15 +1215,8 @@ class PagesApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getPageRequest($author, $slug, $path, string $contentType = self::contentTypes['getPage'][0])
+    public function getPageRequest($slug, $path, string $contentType = self::contentTypes['getPage'][0])
     {
-
-        // verify the required parameter 'author' is set
-        if ($author === null || (is_array($author) && count($author) === 0)) {
-            throw new \InvalidArgumentException(
-                'Missing the required parameter $author when calling getPage'
-            );
-        }
 
         // verify the required parameter 'slug' is set
         if ($slug === null || (is_array($slug) && count($slug) === 0)) {
@@ -1305,7 +1233,7 @@ class PagesApi
         }
 
 
-        $resourcePath = '/api/v1/pages/page/{author}/{slug}';
+        $resourcePath = '/api/v1/pages/page/{slug}';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -1323,14 +1251,6 @@ class PagesApi
         ) ?? []);
 
 
-        // path params
-        if ($author !== null) {
-            $resourcePath = str_replace(
-                '{' . 'author' . '}',
-                ObjectSerializer::toPathValue($author),
-                $resourcePath
-            );
-        }
         // path params
         if ($slug !== null) {
             $resourcePath = str_replace(

--- a/lib/Api/PermissionsApi.php
+++ b/lib/Api/PermissionsApi.php
@@ -134,7 +134,6 @@ class PermissionsApi
      * Checks whether you have all the provided permissions
      *
      * @param string[] $permissions The permissions to check (required)
-     * @param  string $author The owner of the project to check permissions in. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $slug The project slug of the project to check permissions in. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $organization The organization to check permissions in. Must not be used together with &#x60;projectOwner&#x60; and &#x60;projectSlug&#x60; (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['hasAll'] to see the possible values for this operation
@@ -143,9 +142,9 @@ class PermissionsApi
      * @throws \InvalidArgumentException
      * @return \Aternos\HangarApi\Model\PermissionCheck|\Aternos\HangarApi\Model\PermissionCheck|\Aternos\HangarApi\Model\PermissionCheck
      */
-    public function hasAll($permissions, $author = null, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAll'][0])
+    public function hasAll($permissions, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAll'][0])
     {
-        list($response) = $this->hasAllWithHttpInfo($permissions, $author, $slug, $organization, $contentType);
+        list($response) = $this->hasAllWithHttpInfo($permissions, $slug, $organization, $contentType);
         return $response;
     }
 
@@ -155,7 +154,6 @@ class PermissionsApi
      * Checks whether you have all the provided permissions
      *
      * @param string[] $permissions The permissions to check (required)
-     * @param  string $author The owner of the project to check permissions in. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $slug The project slug of the project to check permissions in. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $organization The organization to check permissions in. Must not be used together with &#x60;projectOwner&#x60; and &#x60;projectSlug&#x60; (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['hasAll'] to see the possible values for this operation
@@ -164,9 +162,9 @@ class PermissionsApi
      * @throws \InvalidArgumentException
      * @return array of \Aternos\HangarApi\Model\PermissionCheck|\Aternos\HangarApi\Model\PermissionCheck|\Aternos\HangarApi\Model\PermissionCheck, HTTP status code, HTTP response headers (array of strings)
      */
-    public function hasAllWithHttpInfo($permissions, $author = null, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAll'][0])
+    public function hasAllWithHttpInfo($permissions, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAll'][0])
     {
-        $request = $this->hasAllRequest($permissions, $author, $slug, $organization, $contentType);
+        $request = $this->hasAllRequest($permissions, $slug, $organization, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -304,7 +302,6 @@ class PermissionsApi
      * Checks whether you have all the provided permissions
      *
      * @param string[] $permissions The permissions to check (required)
-     * @param  string $author The owner of the project to check permissions in. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $slug The project slug of the project to check permissions in. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $organization The organization to check permissions in. Must not be used together with &#x60;projectOwner&#x60; and &#x60;projectSlug&#x60; (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['hasAll'] to see the possible values for this operation
@@ -312,9 +309,9 @@ class PermissionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function hasAllAsync($permissions, $author = null, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAll'][0])
+    public function hasAllAsync($permissions, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAll'][0])
     {
-        return $this->hasAllAsyncWithHttpInfo($permissions, $author, $slug, $organization, $contentType)
+        return $this->hasAllAsyncWithHttpInfo($permissions, $slug, $organization, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -328,7 +325,6 @@ class PermissionsApi
      * Checks whether you have all the provided permissions
      *
      * @param string[] $permissions The permissions to check (required)
-     * @param  string $author The owner of the project to check permissions in. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $slug The project slug of the project to check permissions in. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $organization The organization to check permissions in. Must not be used together with &#x60;projectOwner&#x60; and &#x60;projectSlug&#x60; (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['hasAll'] to see the possible values for this operation
@@ -336,10 +332,10 @@ class PermissionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function hasAllAsyncWithHttpInfo($permissions, $author = null, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAll'][0])
+    public function hasAllAsyncWithHttpInfo($permissions, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAll'][0])
     {
         $returnType = '\Aternos\HangarApi\Model\PermissionCheck';
-        $request = $this->hasAllRequest($permissions, $author, $slug, $organization, $contentType);
+        $request = $this->hasAllRequest($permissions, $slug, $organization, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -381,7 +377,6 @@ class PermissionsApi
      * Create request for operation 'hasAll'
      *
      * @param string[] $permissions The permissions to check (required)
-     * @param  string $author The owner of the project to check permissions in. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $slug The project slug of the project to check permissions in. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $organization The organization to check permissions in. Must not be used together with &#x60;projectOwner&#x60; and &#x60;projectSlug&#x60; (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['hasAll'] to see the possible values for this operation
@@ -389,7 +384,7 @@ class PermissionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function hasAllRequest($permissions, $author = null, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAll'][0])
+    public function hasAllRequest($permissions, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAll'][0])
     {
 
         // verify the required parameter 'permissions' is set
@@ -408,7 +403,6 @@ class PermissionsApi
 
 
 
-
         $resourcePath = '/api/v1/permissions/hasAll';
         $formParams = [];
         $queryParams = [];
@@ -424,15 +418,6 @@ class PermissionsApi
             'form', // style
             true, // explode
             true // required
-        ) ?? []);
-        // query params
-        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
-            $author,
-            'author', // param base name
-            'string', // openApiType
-            'form', // style
-            true, // explode
-            false // required
         ) ?? []);
         // query params
         $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
@@ -519,7 +504,6 @@ class PermissionsApi
      * Checks whether you have at least one of the provided permissions
      *
      * @param string[] $permissions The permissions to check (required)
-     * @param  string $author The owner of the project to check permissions in. Must not be used together with &#x60;organizationName (optional)
      * @param  string $slug The slug of the project to check permissions in. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $organization The organization to check permissions in. Must not be used together with &#x60;projectOwner&#x60; and &#x60;projectSlug&#x60; (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['hasAny'] to see the possible values for this operation
@@ -528,9 +512,9 @@ class PermissionsApi
      * @throws \InvalidArgumentException
      * @return \Aternos\HangarApi\Model\PermissionCheck|\Aternos\HangarApi\Model\PermissionCheck|\Aternos\HangarApi\Model\PermissionCheck
      */
-    public function hasAny($permissions, $author = null, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAny'][0])
+    public function hasAny($permissions, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAny'][0])
     {
-        list($response) = $this->hasAnyWithHttpInfo($permissions, $author, $slug, $organization, $contentType);
+        list($response) = $this->hasAnyWithHttpInfo($permissions, $slug, $organization, $contentType);
         return $response;
     }
 
@@ -540,7 +524,6 @@ class PermissionsApi
      * Checks whether you have at least one of the provided permissions
      *
      * @param string[] $permissions The permissions to check (required)
-     * @param  string $author The owner of the project to check permissions in. Must not be used together with &#x60;organizationName (optional)
      * @param  string $slug The slug of the project to check permissions in. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $organization The organization to check permissions in. Must not be used together with &#x60;projectOwner&#x60; and &#x60;projectSlug&#x60; (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['hasAny'] to see the possible values for this operation
@@ -549,9 +532,9 @@ class PermissionsApi
      * @throws \InvalidArgumentException
      * @return array of \Aternos\HangarApi\Model\PermissionCheck|\Aternos\HangarApi\Model\PermissionCheck|\Aternos\HangarApi\Model\PermissionCheck, HTTP status code, HTTP response headers (array of strings)
      */
-    public function hasAnyWithHttpInfo($permissions, $author = null, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAny'][0])
+    public function hasAnyWithHttpInfo($permissions, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAny'][0])
     {
-        $request = $this->hasAnyRequest($permissions, $author, $slug, $organization, $contentType);
+        $request = $this->hasAnyRequest($permissions, $slug, $organization, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -689,7 +672,6 @@ class PermissionsApi
      * Checks whether you have at least one of the provided permissions
      *
      * @param string[] $permissions The permissions to check (required)
-     * @param  string $author The owner of the project to check permissions in. Must not be used together with &#x60;organizationName (optional)
      * @param  string $slug The slug of the project to check permissions in. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $organization The organization to check permissions in. Must not be used together with &#x60;projectOwner&#x60; and &#x60;projectSlug&#x60; (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['hasAny'] to see the possible values for this operation
@@ -697,9 +679,9 @@ class PermissionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function hasAnyAsync($permissions, $author = null, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAny'][0])
+    public function hasAnyAsync($permissions, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAny'][0])
     {
-        return $this->hasAnyAsyncWithHttpInfo($permissions, $author, $slug, $organization, $contentType)
+        return $this->hasAnyAsyncWithHttpInfo($permissions, $slug, $organization, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -713,7 +695,6 @@ class PermissionsApi
      * Checks whether you have at least one of the provided permissions
      *
      * @param string[] $permissions The permissions to check (required)
-     * @param  string $author The owner of the project to check permissions in. Must not be used together with &#x60;organizationName (optional)
      * @param  string $slug The slug of the project to check permissions in. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $organization The organization to check permissions in. Must not be used together with &#x60;projectOwner&#x60; and &#x60;projectSlug&#x60; (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['hasAny'] to see the possible values for this operation
@@ -721,10 +702,10 @@ class PermissionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function hasAnyAsyncWithHttpInfo($permissions, $author = null, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAny'][0])
+    public function hasAnyAsyncWithHttpInfo($permissions, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAny'][0])
     {
         $returnType = '\Aternos\HangarApi\Model\PermissionCheck';
-        $request = $this->hasAnyRequest($permissions, $author, $slug, $organization, $contentType);
+        $request = $this->hasAnyRequest($permissions, $slug, $organization, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -766,7 +747,6 @@ class PermissionsApi
      * Create request for operation 'hasAny'
      *
      * @param string[] $permissions The permissions to check (required)
-     * @param  string $author The owner of the project to check permissions in. Must not be used together with &#x60;organizationName (optional)
      * @param  string $slug The slug of the project to check permissions in. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $organization The organization to check permissions in. Must not be used together with &#x60;projectOwner&#x60; and &#x60;projectSlug&#x60; (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['hasAny'] to see the possible values for this operation
@@ -774,7 +754,7 @@ class PermissionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function hasAnyRequest($permissions, $author = null, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAny'][0])
+    public function hasAnyRequest($permissions, $slug = null, $organization = null, string $contentType = self::contentTypes['hasAny'][0])
     {
 
         // verify the required parameter 'permissions' is set
@@ -784,7 +764,6 @@ class PermissionsApi
             );
         }
         
-
 
 
 
@@ -803,15 +782,6 @@ class PermissionsApi
             'form', // style
             true, // explode
             true // required
-        ) ?? []);
-        // query params
-        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
-            $author,
-            'author', // param base name
-            'string', // openApiType
-            'form', // style
-            true, // explode
-            false // required
         ) ?? []);
         // query params
         $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
@@ -897,7 +867,6 @@ class PermissionsApi
      *
      * Returns your permissions
      *
-     * @param  string $author The owner of the project to get the permissions for. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $slug The slug of the project get the permissions for. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $organization The organization to check permissions in. Must not be used together with &#x60;projectOwner&#x60; and &#x60;projectSlug&#x60; (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['showPermissions'] to see the possible values for this operation
@@ -906,9 +875,9 @@ class PermissionsApi
      * @throws \InvalidArgumentException
      * @return \Aternos\HangarApi\Model\UserPermissions|\Aternos\HangarApi\Model\UserPermissions|\Aternos\HangarApi\Model\UserPermissions
      */
-    public function showPermissions($author = null, $slug = null, $organization = null, string $contentType = self::contentTypes['showPermissions'][0])
+    public function showPermissions($slug = null, $organization = null, string $contentType = self::contentTypes['showPermissions'][0])
     {
-        list($response) = $this->showPermissionsWithHttpInfo($author, $slug, $organization, $contentType);
+        list($response) = $this->showPermissionsWithHttpInfo($slug, $organization, $contentType);
         return $response;
     }
 
@@ -917,7 +886,6 @@ class PermissionsApi
      *
      * Returns your permissions
      *
-     * @param  string $author The owner of the project to get the permissions for. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $slug The slug of the project get the permissions for. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $organization The organization to check permissions in. Must not be used together with &#x60;projectOwner&#x60; and &#x60;projectSlug&#x60; (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['showPermissions'] to see the possible values for this operation
@@ -926,9 +894,9 @@ class PermissionsApi
      * @throws \InvalidArgumentException
      * @return array of \Aternos\HangarApi\Model\UserPermissions|\Aternos\HangarApi\Model\UserPermissions|\Aternos\HangarApi\Model\UserPermissions, HTTP status code, HTTP response headers (array of strings)
      */
-    public function showPermissionsWithHttpInfo($author = null, $slug = null, $organization = null, string $contentType = self::contentTypes['showPermissions'][0])
+    public function showPermissionsWithHttpInfo($slug = null, $organization = null, string $contentType = self::contentTypes['showPermissions'][0])
     {
-        $request = $this->showPermissionsRequest($author, $slug, $organization, $contentType);
+        $request = $this->showPermissionsRequest($slug, $organization, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1065,7 +1033,6 @@ class PermissionsApi
      *
      * Returns your permissions
      *
-     * @param  string $author The owner of the project to get the permissions for. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $slug The slug of the project get the permissions for. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $organization The organization to check permissions in. Must not be used together with &#x60;projectOwner&#x60; and &#x60;projectSlug&#x60; (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['showPermissions'] to see the possible values for this operation
@@ -1073,9 +1040,9 @@ class PermissionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function showPermissionsAsync($author = null, $slug = null, $organization = null, string $contentType = self::contentTypes['showPermissions'][0])
+    public function showPermissionsAsync($slug = null, $organization = null, string $contentType = self::contentTypes['showPermissions'][0])
     {
-        return $this->showPermissionsAsyncWithHttpInfo($author, $slug, $organization, $contentType)
+        return $this->showPermissionsAsyncWithHttpInfo($slug, $organization, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1088,7 +1055,6 @@ class PermissionsApi
      *
      * Returns your permissions
      *
-     * @param  string $author The owner of the project to get the permissions for. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $slug The slug of the project get the permissions for. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $organization The organization to check permissions in. Must not be used together with &#x60;projectOwner&#x60; and &#x60;projectSlug&#x60; (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['showPermissions'] to see the possible values for this operation
@@ -1096,10 +1062,10 @@ class PermissionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function showPermissionsAsyncWithHttpInfo($author = null, $slug = null, $organization = null, string $contentType = self::contentTypes['showPermissions'][0])
+    public function showPermissionsAsyncWithHttpInfo($slug = null, $organization = null, string $contentType = self::contentTypes['showPermissions'][0])
     {
         $returnType = '\Aternos\HangarApi\Model\UserPermissions';
-        $request = $this->showPermissionsRequest($author, $slug, $organization, $contentType);
+        $request = $this->showPermissionsRequest($slug, $organization, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1140,7 +1106,6 @@ class PermissionsApi
     /**
      * Create request for operation 'showPermissions'
      *
-     * @param  string $author The owner of the project to get the permissions for. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $slug The slug of the project get the permissions for. Must not be used together with &#x60;organizationName&#x60; (optional)
      * @param  string $organization The organization to check permissions in. Must not be used together with &#x60;projectOwner&#x60; and &#x60;projectSlug&#x60; (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['showPermissions'] to see the possible values for this operation
@@ -1148,9 +1113,8 @@ class PermissionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function showPermissionsRequest($author = null, $slug = null, $organization = null, string $contentType = self::contentTypes['showPermissions'][0])
+    public function showPermissionsRequest($slug = null, $organization = null, string $contentType = self::contentTypes['showPermissions'][0])
     {
-
 
 
 
@@ -1162,15 +1126,6 @@ class PermissionsApi
         $httpBody = '';
         $multipart = false;
 
-        // query params
-        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
-            $author,
-            'author', // param base name
-            'string', // openApiType
-            'form', // style
-            true, // explode
-            false // required
-        ) ?? []);
         // query params
         $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
             $slug,

--- a/lib/Api/ProjectsApi.php
+++ b/lib/Api/ProjectsApi.php
@@ -143,7 +143,6 @@ class ProjectsApi
      *
      * Returns info on a specific project
      *
-     * @param  string $author The author of the project to return (required)
      * @param  string $slug The slug of the project to return (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProject'] to see the possible values for this operation
      *
@@ -151,9 +150,9 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \Aternos\HangarApi\Model\Project|\Aternos\HangarApi\Model\Project|\Aternos\HangarApi\Model\Project
      */
-    public function getProject($author, $slug, string $contentType = self::contentTypes['getProject'][0])
+    public function getProject($slug, string $contentType = self::contentTypes['getProject'][0])
     {
-        list($response) = $this->getProjectWithHttpInfo($author, $slug, $contentType);
+        list($response) = $this->getProjectWithHttpInfo($slug, $contentType);
         return $response;
     }
 
@@ -162,7 +161,6 @@ class ProjectsApi
      *
      * Returns info on a specific project
      *
-     * @param  string $author The author of the project to return (required)
      * @param  string $slug The slug of the project to return (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProject'] to see the possible values for this operation
      *
@@ -170,9 +168,9 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return array of \Aternos\HangarApi\Model\Project|\Aternos\HangarApi\Model\Project|\Aternos\HangarApi\Model\Project, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getProjectWithHttpInfo($author, $slug, string $contentType = self::contentTypes['getProject'][0])
+    public function getProjectWithHttpInfo($slug, string $contentType = self::contentTypes['getProject'][0])
     {
-        $request = $this->getProjectRequest($author, $slug, $contentType);
+        $request = $this->getProjectRequest($slug, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -309,16 +307,15 @@ class ProjectsApi
      *
      * Returns info on a specific project
      *
-     * @param  string $author The author of the project to return (required)
      * @param  string $slug The slug of the project to return (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProject'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getProjectAsync($author, $slug, string $contentType = self::contentTypes['getProject'][0])
+    public function getProjectAsync($slug, string $contentType = self::contentTypes['getProject'][0])
     {
-        return $this->getProjectAsyncWithHttpInfo($author, $slug, $contentType)
+        return $this->getProjectAsyncWithHttpInfo($slug, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -331,17 +328,16 @@ class ProjectsApi
      *
      * Returns info on a specific project
      *
-     * @param  string $author The author of the project to return (required)
      * @param  string $slug The slug of the project to return (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProject'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getProjectAsyncWithHttpInfo($author, $slug, string $contentType = self::contentTypes['getProject'][0])
+    public function getProjectAsyncWithHttpInfo($slug, string $contentType = self::contentTypes['getProject'][0])
     {
         $returnType = '\Aternos\HangarApi\Model\Project';
-        $request = $this->getProjectRequest($author, $slug, $contentType);
+        $request = $this->getProjectRequest($slug, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -382,22 +378,14 @@ class ProjectsApi
     /**
      * Create request for operation 'getProject'
      *
-     * @param  string $author The author of the project to return (required)
      * @param  string $slug The slug of the project to return (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProject'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getProjectRequest($author, $slug, string $contentType = self::contentTypes['getProject'][0])
+    public function getProjectRequest($slug, string $contentType = self::contentTypes['getProject'][0])
     {
-
-        // verify the required parameter 'author' is set
-        if ($author === null || (is_array($author) && count($author) === 0)) {
-            throw new \InvalidArgumentException(
-                'Missing the required parameter $author when calling getProject'
-            );
-        }
 
         // verify the required parameter 'slug' is set
         if ($slug === null || (is_array($slug) && count($slug) === 0)) {
@@ -407,7 +395,7 @@ class ProjectsApi
         }
 
 
-        $resourcePath = '/api/v1/projects/{author}/{slug}';
+        $resourcePath = '/api/v1/projects/{slug}';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -416,14 +404,6 @@ class ProjectsApi
 
 
 
-        // path params
-        if ($author !== null) {
-            $resourcePath = str_replace(
-                '{' . 'author' . '}',
-                ObjectSerializer::toPathValue($author),
-                $resourcePath
-            );
-        }
         // path params
         if ($slug !== null) {
             $resourcePath = str_replace(
@@ -496,7 +476,6 @@ class ProjectsApi
      *
      * Returns the members of a project
      *
-     * @param  string $author The author of the project to return members for (required)
      * @param  string $slug The slug of the project to return members for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProjectMembers'] to see the possible values for this operation
@@ -505,9 +484,9 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \Aternos\HangarApi\Model\PaginatedResultProjectMember|\Aternos\HangarApi\Model\PaginatedResultProjectMember|\Aternos\HangarApi\Model\PaginatedResultProjectMember
      */
-    public function getProjectMembers($author, $slug, $pagination, string $contentType = self::contentTypes['getProjectMembers'][0])
+    public function getProjectMembers($slug, $pagination, string $contentType = self::contentTypes['getProjectMembers'][0])
     {
-        list($response) = $this->getProjectMembersWithHttpInfo($author, $slug, $pagination, $contentType);
+        list($response) = $this->getProjectMembersWithHttpInfo($slug, $pagination, $contentType);
         return $response;
     }
 
@@ -516,7 +495,6 @@ class ProjectsApi
      *
      * Returns the members of a project
      *
-     * @param  string $author The author of the project to return members for (required)
      * @param  string $slug The slug of the project to return members for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProjectMembers'] to see the possible values for this operation
@@ -525,9 +503,9 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return array of \Aternos\HangarApi\Model\PaginatedResultProjectMember|\Aternos\HangarApi\Model\PaginatedResultProjectMember|\Aternos\HangarApi\Model\PaginatedResultProjectMember, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getProjectMembersWithHttpInfo($author, $slug, $pagination, string $contentType = self::contentTypes['getProjectMembers'][0])
+    public function getProjectMembersWithHttpInfo($slug, $pagination, string $contentType = self::contentTypes['getProjectMembers'][0])
     {
-        $request = $this->getProjectMembersRequest($author, $slug, $pagination, $contentType);
+        $request = $this->getProjectMembersRequest($slug, $pagination, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -664,7 +642,6 @@ class ProjectsApi
      *
      * Returns the members of a project
      *
-     * @param  string $author The author of the project to return members for (required)
      * @param  string $slug The slug of the project to return members for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProjectMembers'] to see the possible values for this operation
@@ -672,9 +649,9 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getProjectMembersAsync($author, $slug, $pagination, string $contentType = self::contentTypes['getProjectMembers'][0])
+    public function getProjectMembersAsync($slug, $pagination, string $contentType = self::contentTypes['getProjectMembers'][0])
     {
-        return $this->getProjectMembersAsyncWithHttpInfo($author, $slug, $pagination, $contentType)
+        return $this->getProjectMembersAsyncWithHttpInfo($slug, $pagination, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -687,7 +664,6 @@ class ProjectsApi
      *
      * Returns the members of a project
      *
-     * @param  string $author The author of the project to return members for (required)
      * @param  string $slug The slug of the project to return members for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProjectMembers'] to see the possible values for this operation
@@ -695,10 +671,10 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getProjectMembersAsyncWithHttpInfo($author, $slug, $pagination, string $contentType = self::contentTypes['getProjectMembers'][0])
+    public function getProjectMembersAsyncWithHttpInfo($slug, $pagination, string $contentType = self::contentTypes['getProjectMembers'][0])
     {
         $returnType = '\Aternos\HangarApi\Model\PaginatedResultProjectMember';
-        $request = $this->getProjectMembersRequest($author, $slug, $pagination, $contentType);
+        $request = $this->getProjectMembersRequest($slug, $pagination, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -739,7 +715,6 @@ class ProjectsApi
     /**
      * Create request for operation 'getProjectMembers'
      *
-     * @param  string $author The author of the project to return members for (required)
      * @param  string $slug The slug of the project to return members for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProjectMembers'] to see the possible values for this operation
@@ -747,15 +722,8 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getProjectMembersRequest($author, $slug, $pagination, string $contentType = self::contentTypes['getProjectMembers'][0])
+    public function getProjectMembersRequest($slug, $pagination, string $contentType = self::contentTypes['getProjectMembers'][0])
     {
-
-        // verify the required parameter 'author' is set
-        if ($author === null || (is_array($author) && count($author) === 0)) {
-            throw new \InvalidArgumentException(
-                'Missing the required parameter $author when calling getProjectMembers'
-            );
-        }
 
         // verify the required parameter 'slug' is set
         if ($slug === null || (is_array($slug) && count($slug) === 0)) {
@@ -772,7 +740,7 @@ class ProjectsApi
         }
 
 
-        $resourcePath = '/api/v1/projects/{author}/{slug}/members';
+        $resourcePath = '/api/v1/projects/{slug}/members';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -790,14 +758,6 @@ class ProjectsApi
         ) ?? []);
 
 
-        // path params
-        if ($author !== null) {
-            $resourcePath = str_replace(
-                '{' . 'author' . '}',
-                ObjectSerializer::toPathValue($author),
-                $resourcePath
-            );
-        }
         // path params
         if ($slug !== null) {
             $resourcePath = str_replace(
@@ -870,7 +830,6 @@ class ProjectsApi
      *
      * Returns the stargazers of a project
      *
-     * @param  string $author The author of the project to return stargazers for (required)
      * @param  string $slug The slug of the project to return stargazers for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProjectStargazers'] to see the possible values for this operation
@@ -879,9 +838,9 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \Aternos\HangarApi\Model\PaginatedResultUser|\Aternos\HangarApi\Model\PaginatedResultUser|\Aternos\HangarApi\Model\PaginatedResultUser
      */
-    public function getProjectStargazers($author, $slug, $pagination, string $contentType = self::contentTypes['getProjectStargazers'][0])
+    public function getProjectStargazers($slug, $pagination, string $contentType = self::contentTypes['getProjectStargazers'][0])
     {
-        list($response) = $this->getProjectStargazersWithHttpInfo($author, $slug, $pagination, $contentType);
+        list($response) = $this->getProjectStargazersWithHttpInfo($slug, $pagination, $contentType);
         return $response;
     }
 
@@ -890,7 +849,6 @@ class ProjectsApi
      *
      * Returns the stargazers of a project
      *
-     * @param  string $author The author of the project to return stargazers for (required)
      * @param  string $slug The slug of the project to return stargazers for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProjectStargazers'] to see the possible values for this operation
@@ -899,9 +857,9 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return array of \Aternos\HangarApi\Model\PaginatedResultUser|\Aternos\HangarApi\Model\PaginatedResultUser|\Aternos\HangarApi\Model\PaginatedResultUser, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getProjectStargazersWithHttpInfo($author, $slug, $pagination, string $contentType = self::contentTypes['getProjectStargazers'][0])
+    public function getProjectStargazersWithHttpInfo($slug, $pagination, string $contentType = self::contentTypes['getProjectStargazers'][0])
     {
-        $request = $this->getProjectStargazersRequest($author, $slug, $pagination, $contentType);
+        $request = $this->getProjectStargazersRequest($slug, $pagination, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1038,7 +996,6 @@ class ProjectsApi
      *
      * Returns the stargazers of a project
      *
-     * @param  string $author The author of the project to return stargazers for (required)
      * @param  string $slug The slug of the project to return stargazers for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProjectStargazers'] to see the possible values for this operation
@@ -1046,9 +1003,9 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getProjectStargazersAsync($author, $slug, $pagination, string $contentType = self::contentTypes['getProjectStargazers'][0])
+    public function getProjectStargazersAsync($slug, $pagination, string $contentType = self::contentTypes['getProjectStargazers'][0])
     {
-        return $this->getProjectStargazersAsyncWithHttpInfo($author, $slug, $pagination, $contentType)
+        return $this->getProjectStargazersAsyncWithHttpInfo($slug, $pagination, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1061,7 +1018,6 @@ class ProjectsApi
      *
      * Returns the stargazers of a project
      *
-     * @param  string $author The author of the project to return stargazers for (required)
      * @param  string $slug The slug of the project to return stargazers for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProjectStargazers'] to see the possible values for this operation
@@ -1069,10 +1025,10 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getProjectStargazersAsyncWithHttpInfo($author, $slug, $pagination, string $contentType = self::contentTypes['getProjectStargazers'][0])
+    public function getProjectStargazersAsyncWithHttpInfo($slug, $pagination, string $contentType = self::contentTypes['getProjectStargazers'][0])
     {
         $returnType = '\Aternos\HangarApi\Model\PaginatedResultUser';
-        $request = $this->getProjectStargazersRequest($author, $slug, $pagination, $contentType);
+        $request = $this->getProjectStargazersRequest($slug, $pagination, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1113,7 +1069,6 @@ class ProjectsApi
     /**
      * Create request for operation 'getProjectStargazers'
      *
-     * @param  string $author The author of the project to return stargazers for (required)
      * @param  string $slug The slug of the project to return stargazers for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProjectStargazers'] to see the possible values for this operation
@@ -1121,15 +1076,8 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getProjectStargazersRequest($author, $slug, $pagination, string $contentType = self::contentTypes['getProjectStargazers'][0])
+    public function getProjectStargazersRequest($slug, $pagination, string $contentType = self::contentTypes['getProjectStargazers'][0])
     {
-
-        // verify the required parameter 'author' is set
-        if ($author === null || (is_array($author) && count($author) === 0)) {
-            throw new \InvalidArgumentException(
-                'Missing the required parameter $author when calling getProjectStargazers'
-            );
-        }
 
         // verify the required parameter 'slug' is set
         if ($slug === null || (is_array($slug) && count($slug) === 0)) {
@@ -1146,7 +1094,7 @@ class ProjectsApi
         }
 
 
-        $resourcePath = '/api/v1/projects/{author}/{slug}/stargazers';
+        $resourcePath = '/api/v1/projects/{slug}/stargazers';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -1164,14 +1112,6 @@ class ProjectsApi
         ) ?? []);
 
 
-        // path params
-        if ($author !== null) {
-            $resourcePath = str_replace(
-                '{' . 'author' . '}',
-                ObjectSerializer::toPathValue($author),
-                $resourcePath
-            );
-        }
         // path params
         if ($slug !== null) {
             $resourcePath = str_replace(
@@ -1244,7 +1184,6 @@ class ProjectsApi
      *
      * Returns the watchers of a project
      *
-     * @param  string $author The author of the project to return watchers for (required)
      * @param  string $slug The slug of the project to return watchers for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProjectWatchers'] to see the possible values for this operation
@@ -1253,9 +1192,9 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \Aternos\HangarApi\Model\PaginatedResultUser|\Aternos\HangarApi\Model\PaginatedResultUser|\Aternos\HangarApi\Model\PaginatedResultUser
      */
-    public function getProjectWatchers($author, $slug, $pagination, string $contentType = self::contentTypes['getProjectWatchers'][0])
+    public function getProjectWatchers($slug, $pagination, string $contentType = self::contentTypes['getProjectWatchers'][0])
     {
-        list($response) = $this->getProjectWatchersWithHttpInfo($author, $slug, $pagination, $contentType);
+        list($response) = $this->getProjectWatchersWithHttpInfo($slug, $pagination, $contentType);
         return $response;
     }
 
@@ -1264,7 +1203,6 @@ class ProjectsApi
      *
      * Returns the watchers of a project
      *
-     * @param  string $author The author of the project to return watchers for (required)
      * @param  string $slug The slug of the project to return watchers for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProjectWatchers'] to see the possible values for this operation
@@ -1273,9 +1211,9 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return array of \Aternos\HangarApi\Model\PaginatedResultUser|\Aternos\HangarApi\Model\PaginatedResultUser|\Aternos\HangarApi\Model\PaginatedResultUser, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getProjectWatchersWithHttpInfo($author, $slug, $pagination, string $contentType = self::contentTypes['getProjectWatchers'][0])
+    public function getProjectWatchersWithHttpInfo($slug, $pagination, string $contentType = self::contentTypes['getProjectWatchers'][0])
     {
-        $request = $this->getProjectWatchersRequest($author, $slug, $pagination, $contentType);
+        $request = $this->getProjectWatchersRequest($slug, $pagination, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1412,7 +1350,6 @@ class ProjectsApi
      *
      * Returns the watchers of a project
      *
-     * @param  string $author The author of the project to return watchers for (required)
      * @param  string $slug The slug of the project to return watchers for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProjectWatchers'] to see the possible values for this operation
@@ -1420,9 +1357,9 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getProjectWatchersAsync($author, $slug, $pagination, string $contentType = self::contentTypes['getProjectWatchers'][0])
+    public function getProjectWatchersAsync($slug, $pagination, string $contentType = self::contentTypes['getProjectWatchers'][0])
     {
-        return $this->getProjectWatchersAsyncWithHttpInfo($author, $slug, $pagination, $contentType)
+        return $this->getProjectWatchersAsyncWithHttpInfo($slug, $pagination, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1435,7 +1372,6 @@ class ProjectsApi
      *
      * Returns the watchers of a project
      *
-     * @param  string $author The author of the project to return watchers for (required)
      * @param  string $slug The slug of the project to return watchers for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProjectWatchers'] to see the possible values for this operation
@@ -1443,10 +1379,10 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getProjectWatchersAsyncWithHttpInfo($author, $slug, $pagination, string $contentType = self::contentTypes['getProjectWatchers'][0])
+    public function getProjectWatchersAsyncWithHttpInfo($slug, $pagination, string $contentType = self::contentTypes['getProjectWatchers'][0])
     {
         $returnType = '\Aternos\HangarApi\Model\PaginatedResultUser';
-        $request = $this->getProjectWatchersRequest($author, $slug, $pagination, $contentType);
+        $request = $this->getProjectWatchersRequest($slug, $pagination, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1487,7 +1423,6 @@ class ProjectsApi
     /**
      * Create request for operation 'getProjectWatchers'
      *
-     * @param  string $author The author of the project to return watchers for (required)
      * @param  string $slug The slug of the project to return watchers for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getProjectWatchers'] to see the possible values for this operation
@@ -1495,15 +1430,8 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getProjectWatchersRequest($author, $slug, $pagination, string $contentType = self::contentTypes['getProjectWatchers'][0])
+    public function getProjectWatchersRequest($slug, $pagination, string $contentType = self::contentTypes['getProjectWatchers'][0])
     {
-
-        // verify the required parameter 'author' is set
-        if ($author === null || (is_array($author) && count($author) === 0)) {
-            throw new \InvalidArgumentException(
-                'Missing the required parameter $author when calling getProjectWatchers'
-            );
-        }
 
         // verify the required parameter 'slug' is set
         if ($slug === null || (is_array($slug) && count($slug) === 0)) {
@@ -1520,7 +1448,7 @@ class ProjectsApi
         }
 
 
-        $resourcePath = '/api/v1/projects/{author}/{slug}/watchers';
+        $resourcePath = '/api/v1/projects/{slug}/watchers';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -1538,14 +1466,6 @@ class ProjectsApi
         ) ?? []);
 
 
-        // path params
-        if ($author !== null) {
-            $resourcePath = str_replace(
-                '{' . 'author' . '}',
-                ObjectSerializer::toPathValue($author),
-                $resourcePath
-            );
-        }
         // path params
         if ($slug !== null) {
             $resourcePath = str_replace(
@@ -1619,7 +1539,7 @@ class ProjectsApi
      * Searches the projects on Hangar
      *
      * @param  RequestPagination $pagination Pagination information (required)
-     * @param  bool $order_with_relevance Whether projects should be sorted by the relevance to the given query (optional, default to true)
+     * @param  bool $prioritize_exact_match Whether to prioritize the project with an exact name match if present (optional, default to true)
      * @param  string $sort Used to sort the result (optional)
      * @param  string $category A category to filter for (optional)
      * @param  string $platform A platform to filter for (optional)
@@ -1634,9 +1554,9 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \Aternos\HangarApi\Model\PaginatedResultProject|\Aternos\HangarApi\Model\PaginatedResultProject|\Aternos\HangarApi\Model\PaginatedResultProject
      */
-    public function getProjects($pagination, $order_with_relevance = true, $sort = null, $category = null, $platform = null, $owner = null, $q = null, $license = null, $version = null, $tag = null, string $contentType = self::contentTypes['getProjects'][0])
+    public function getProjects($pagination, $prioritize_exact_match = true, $sort = null, $category = null, $platform = null, $owner = null, $q = null, $license = null, $version = null, $tag = null, string $contentType = self::contentTypes['getProjects'][0])
     {
-        list($response) = $this->getProjectsWithHttpInfo($pagination, $order_with_relevance, $sort, $category, $platform, $owner, $q, $license, $version, $tag, $contentType);
+        list($response) = $this->getProjectsWithHttpInfo($pagination, $prioritize_exact_match, $sort, $category, $platform, $owner, $q, $license, $version, $tag, $contentType);
         return $response;
     }
 
@@ -1646,7 +1566,7 @@ class ProjectsApi
      * Searches the projects on Hangar
      *
      * @param  RequestPagination $pagination Pagination information (required)
-     * @param  bool $order_with_relevance Whether projects should be sorted by the relevance to the given query (optional, default to true)
+     * @param  bool $prioritize_exact_match Whether to prioritize the project with an exact name match if present (optional, default to true)
      * @param  string $sort Used to sort the result (optional)
      * @param  string $category A category to filter for (optional)
      * @param  string $platform A platform to filter for (optional)
@@ -1661,9 +1581,9 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return array of \Aternos\HangarApi\Model\PaginatedResultProject|\Aternos\HangarApi\Model\PaginatedResultProject|\Aternos\HangarApi\Model\PaginatedResultProject, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getProjectsWithHttpInfo($pagination, $order_with_relevance = true, $sort = null, $category = null, $platform = null, $owner = null, $q = null, $license = null, $version = null, $tag = null, string $contentType = self::contentTypes['getProjects'][0])
+    public function getProjectsWithHttpInfo($pagination, $prioritize_exact_match = true, $sort = null, $category = null, $platform = null, $owner = null, $q = null, $license = null, $version = null, $tag = null, string $contentType = self::contentTypes['getProjects'][0])
     {
-        $request = $this->getProjectsRequest($pagination, $order_with_relevance, $sort, $category, $platform, $owner, $q, $license, $version, $tag, $contentType);
+        $request = $this->getProjectsRequest($pagination, $prioritize_exact_match, $sort, $category, $platform, $owner, $q, $license, $version, $tag, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1801,7 +1721,7 @@ class ProjectsApi
      * Searches the projects on Hangar
      *
      * @param  RequestPagination $pagination Pagination information (required)
-     * @param  bool $order_with_relevance Whether projects should be sorted by the relevance to the given query (optional, default to true)
+     * @param  bool $prioritize_exact_match Whether to prioritize the project with an exact name match if present (optional, default to true)
      * @param  string $sort Used to sort the result (optional)
      * @param  string $category A category to filter for (optional)
      * @param  string $platform A platform to filter for (optional)
@@ -1815,9 +1735,9 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getProjectsAsync($pagination, $order_with_relevance = true, $sort = null, $category = null, $platform = null, $owner = null, $q = null, $license = null, $version = null, $tag = null, string $contentType = self::contentTypes['getProjects'][0])
+    public function getProjectsAsync($pagination, $prioritize_exact_match = true, $sort = null, $category = null, $platform = null, $owner = null, $q = null, $license = null, $version = null, $tag = null, string $contentType = self::contentTypes['getProjects'][0])
     {
-        return $this->getProjectsAsyncWithHttpInfo($pagination, $order_with_relevance, $sort, $category, $platform, $owner, $q, $license, $version, $tag, $contentType)
+        return $this->getProjectsAsyncWithHttpInfo($pagination, $prioritize_exact_match, $sort, $category, $platform, $owner, $q, $license, $version, $tag, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1831,7 +1751,7 @@ class ProjectsApi
      * Searches the projects on Hangar
      *
      * @param  RequestPagination $pagination Pagination information (required)
-     * @param  bool $order_with_relevance Whether projects should be sorted by the relevance to the given query (optional, default to true)
+     * @param  bool $prioritize_exact_match Whether to prioritize the project with an exact name match if present (optional, default to true)
      * @param  string $sort Used to sort the result (optional)
      * @param  string $category A category to filter for (optional)
      * @param  string $platform A platform to filter for (optional)
@@ -1845,10 +1765,10 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getProjectsAsyncWithHttpInfo($pagination, $order_with_relevance = true, $sort = null, $category = null, $platform = null, $owner = null, $q = null, $license = null, $version = null, $tag = null, string $contentType = self::contentTypes['getProjects'][0])
+    public function getProjectsAsyncWithHttpInfo($pagination, $prioritize_exact_match = true, $sort = null, $category = null, $platform = null, $owner = null, $q = null, $license = null, $version = null, $tag = null, string $contentType = self::contentTypes['getProjects'][0])
     {
         $returnType = '\Aternos\HangarApi\Model\PaginatedResultProject';
-        $request = $this->getProjectsRequest($pagination, $order_with_relevance, $sort, $category, $platform, $owner, $q, $license, $version, $tag, $contentType);
+        $request = $this->getProjectsRequest($pagination, $prioritize_exact_match, $sort, $category, $platform, $owner, $q, $license, $version, $tag, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1890,7 +1810,7 @@ class ProjectsApi
      * Create request for operation 'getProjects'
      *
      * @param  RequestPagination $pagination Pagination information (required)
-     * @param  bool $order_with_relevance Whether projects should be sorted by the relevance to the given query (optional, default to true)
+     * @param  bool $prioritize_exact_match Whether to prioritize the project with an exact name match if present (optional, default to true)
      * @param  string $sort Used to sort the result (optional)
      * @param  string $category A category to filter for (optional)
      * @param  string $platform A platform to filter for (optional)
@@ -1904,7 +1824,7 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getProjectsRequest($pagination, $order_with_relevance = true, $sort = null, $category = null, $platform = null, $owner = null, $q = null, $license = null, $version = null, $tag = null, string $contentType = self::contentTypes['getProjects'][0])
+    public function getProjectsRequest($pagination, $prioritize_exact_match = true, $sort = null, $category = null, $platform = null, $owner = null, $q = null, $license = null, $version = null, $tag = null, string $contentType = self::contentTypes['getProjects'][0])
     {
 
         // verify the required parameter 'pagination' is set
@@ -1933,8 +1853,8 @@ class ProjectsApi
 
         // query params
         $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
-            $order_with_relevance,
-            'orderWithRelevance', // param base name
+            $prioritize_exact_match,
+            'prioritizeExactMatch', // param base name
             'boolean', // openApiType
             'form', // style
             true, // explode
@@ -2087,7 +2007,6 @@ class ProjectsApi
      *
      * Returns the stats for a project
      *
-     * @param  string $author The author of the project to return stats for (required)
      * @param  string $slug The slug of the project to return stats for (required)
      * @param  string $from_date The first date to include in the result (required)
      * @param  string $to_date The last date to include in the result (required)
@@ -2097,9 +2016,9 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return array<string,\Aternos\HangarApi\Model\DayProjectStats>|array<string,\Aternos\HangarApi\Model\DayProjectStats>|array<string,\Aternos\HangarApi\Model\DayProjectStats>
      */
-    public function showProjectStats($author, $slug, $from_date, $to_date, string $contentType = self::contentTypes['showProjectStats'][0])
+    public function showProjectStats($slug, $from_date, $to_date, string $contentType = self::contentTypes['showProjectStats'][0])
     {
-        list($response) = $this->showProjectStatsWithHttpInfo($author, $slug, $from_date, $to_date, $contentType);
+        list($response) = $this->showProjectStatsWithHttpInfo($slug, $from_date, $to_date, $contentType);
         return $response;
     }
 
@@ -2108,7 +2027,6 @@ class ProjectsApi
      *
      * Returns the stats for a project
      *
-     * @param  string $author The author of the project to return stats for (required)
      * @param  string $slug The slug of the project to return stats for (required)
      * @param  string $from_date The first date to include in the result (required)
      * @param  string $to_date The last date to include in the result (required)
@@ -2118,9 +2036,9 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return array of array<string,\Aternos\HangarApi\Model\DayProjectStats>|array<string,\Aternos\HangarApi\Model\DayProjectStats>|array<string,\Aternos\HangarApi\Model\DayProjectStats>, HTTP status code, HTTP response headers (array of strings)
      */
-    public function showProjectStatsWithHttpInfo($author, $slug, $from_date, $to_date, string $contentType = self::contentTypes['showProjectStats'][0])
+    public function showProjectStatsWithHttpInfo($slug, $from_date, $to_date, string $contentType = self::contentTypes['showProjectStats'][0])
     {
-        $request = $this->showProjectStatsRequest($author, $slug, $from_date, $to_date, $contentType);
+        $request = $this->showProjectStatsRequest($slug, $from_date, $to_date, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -2257,7 +2175,6 @@ class ProjectsApi
      *
      * Returns the stats for a project
      *
-     * @param  string $author The author of the project to return stats for (required)
      * @param  string $slug The slug of the project to return stats for (required)
      * @param  string $from_date The first date to include in the result (required)
      * @param  string $to_date The last date to include in the result (required)
@@ -2266,9 +2183,9 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function showProjectStatsAsync($author, $slug, $from_date, $to_date, string $contentType = self::contentTypes['showProjectStats'][0])
+    public function showProjectStatsAsync($slug, $from_date, $to_date, string $contentType = self::contentTypes['showProjectStats'][0])
     {
-        return $this->showProjectStatsAsyncWithHttpInfo($author, $slug, $from_date, $to_date, $contentType)
+        return $this->showProjectStatsAsyncWithHttpInfo($slug, $from_date, $to_date, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -2281,7 +2198,6 @@ class ProjectsApi
      *
      * Returns the stats for a project
      *
-     * @param  string $author The author of the project to return stats for (required)
      * @param  string $slug The slug of the project to return stats for (required)
      * @param  string $from_date The first date to include in the result (required)
      * @param  string $to_date The last date to include in the result (required)
@@ -2290,10 +2206,10 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function showProjectStatsAsyncWithHttpInfo($author, $slug, $from_date, $to_date, string $contentType = self::contentTypes['showProjectStats'][0])
+    public function showProjectStatsAsyncWithHttpInfo($slug, $from_date, $to_date, string $contentType = self::contentTypes['showProjectStats'][0])
     {
         $returnType = 'array<string,\Aternos\HangarApi\Model\DayProjectStats>';
-        $request = $this->showProjectStatsRequest($author, $slug, $from_date, $to_date, $contentType);
+        $request = $this->showProjectStatsRequest($slug, $from_date, $to_date, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -2334,7 +2250,6 @@ class ProjectsApi
     /**
      * Create request for operation 'showProjectStats'
      *
-     * @param  string $author The author of the project to return stats for (required)
      * @param  string $slug The slug of the project to return stats for (required)
      * @param  string $from_date The first date to include in the result (required)
      * @param  string $to_date The last date to include in the result (required)
@@ -2343,15 +2258,8 @@ class ProjectsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function showProjectStatsRequest($author, $slug, $from_date, $to_date, string $contentType = self::contentTypes['showProjectStats'][0])
+    public function showProjectStatsRequest($slug, $from_date, $to_date, string $contentType = self::contentTypes['showProjectStats'][0])
     {
-
-        // verify the required parameter 'author' is set
-        if ($author === null || (is_array($author) && count($author) === 0)) {
-            throw new \InvalidArgumentException(
-                'Missing the required parameter $author when calling showProjectStats'
-            );
-        }
 
         // verify the required parameter 'slug' is set
         if ($slug === null || (is_array($slug) && count($slug) === 0)) {
@@ -2375,7 +2283,7 @@ class ProjectsApi
         }
 
 
-        $resourcePath = '/api/v1/projects/{author}/{slug}/stats';
+        $resourcePath = '/api/v1/projects/{slug}/stats';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -2402,14 +2310,6 @@ class ProjectsApi
         ) ?? []);
 
 
-        // path params
-        if ($author !== null) {
-            $resourcePath = str_replace(
-                '{' . 'author' . '}',
-                ObjectSerializer::toPathValue($author),
-                $resourcePath
-            );
-        }
         // path params
         if ($slug !== null) {
             $resourcePath = str_replace(

--- a/lib/Api/UsersApi.php
+++ b/lib/Api/UsersApi.php
@@ -146,6 +146,7 @@ class UsersApi
      *
      * Returns all users with at least one public project
      *
+     * @param  string $query The search query (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $sort Used to sort the result (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getAuthors'] to see the possible values for this operation
@@ -154,9 +155,9 @@ class UsersApi
      * @throws \InvalidArgumentException
      * @return \Aternos\HangarApi\Model\PaginatedResultUser|\Aternos\HangarApi\Model\PaginatedResultUser|\Aternos\HangarApi\Model\PaginatedResultUser
      */
-    public function getAuthors($pagination, $sort = null, string $contentType = self::contentTypes['getAuthors'][0])
+    public function getAuthors($query, $pagination, $sort = null, string $contentType = self::contentTypes['getAuthors'][0])
     {
-        list($response) = $this->getAuthorsWithHttpInfo($pagination, $sort, $contentType);
+        list($response) = $this->getAuthorsWithHttpInfo($query, $pagination, $sort, $contentType);
         return $response;
     }
 
@@ -165,6 +166,7 @@ class UsersApi
      *
      * Returns all users with at least one public project
      *
+     * @param  string $query The search query (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $sort Used to sort the result (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getAuthors'] to see the possible values for this operation
@@ -173,9 +175,9 @@ class UsersApi
      * @throws \InvalidArgumentException
      * @return array of \Aternos\HangarApi\Model\PaginatedResultUser|\Aternos\HangarApi\Model\PaginatedResultUser|\Aternos\HangarApi\Model\PaginatedResultUser, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getAuthorsWithHttpInfo($pagination, $sort = null, string $contentType = self::contentTypes['getAuthors'][0])
+    public function getAuthorsWithHttpInfo($query, $pagination, $sort = null, string $contentType = self::contentTypes['getAuthors'][0])
     {
-        $request = $this->getAuthorsRequest($pagination, $sort, $contentType);
+        $request = $this->getAuthorsRequest($query, $pagination, $sort, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -312,6 +314,7 @@ class UsersApi
      *
      * Returns all users with at least one public project
      *
+     * @param  string $query The search query (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $sort Used to sort the result (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getAuthors'] to see the possible values for this operation
@@ -319,9 +322,9 @@ class UsersApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getAuthorsAsync($pagination, $sort = null, string $contentType = self::contentTypes['getAuthors'][0])
+    public function getAuthorsAsync($query, $pagination, $sort = null, string $contentType = self::contentTypes['getAuthors'][0])
     {
-        return $this->getAuthorsAsyncWithHttpInfo($pagination, $sort, $contentType)
+        return $this->getAuthorsAsyncWithHttpInfo($query, $pagination, $sort, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -334,6 +337,7 @@ class UsersApi
      *
      * Returns all users with at least one public project
      *
+     * @param  string $query The search query (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $sort Used to sort the result (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getAuthors'] to see the possible values for this operation
@@ -341,10 +345,10 @@ class UsersApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getAuthorsAsyncWithHttpInfo($pagination, $sort = null, string $contentType = self::contentTypes['getAuthors'][0])
+    public function getAuthorsAsyncWithHttpInfo($query, $pagination, $sort = null, string $contentType = self::contentTypes['getAuthors'][0])
     {
         $returnType = '\Aternos\HangarApi\Model\PaginatedResultUser';
-        $request = $this->getAuthorsRequest($pagination, $sort, $contentType);
+        $request = $this->getAuthorsRequest($query, $pagination, $sort, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -385,6 +389,7 @@ class UsersApi
     /**
      * Create request for operation 'getAuthors'
      *
+     * @param  string $query The search query (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $sort Used to sort the result (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getAuthors'] to see the possible values for this operation
@@ -392,8 +397,15 @@ class UsersApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getAuthorsRequest($pagination, $sort = null, string $contentType = self::contentTypes['getAuthors'][0])
+    public function getAuthorsRequest($query, $pagination, $sort = null, string $contentType = self::contentTypes['getAuthors'][0])
     {
+
+        // verify the required parameter 'query' is set
+        if ($query === null || (is_array($query) && count($query) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $query when calling getAuthors'
+            );
+        }
 
         // verify the required parameter 'pagination' is set
         if ($pagination === null || (is_array($pagination) && count($pagination) === 0)) {
@@ -411,6 +423,15 @@ class UsersApi
         $httpBody = '';
         $multipart = false;
 
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $query,
+            'query', // param base name
+            'string', // openApiType
+            'form', // style
+            true, // explode
+            true // required
+        ) ?? []);
         // query params
         $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
             $pagination,
@@ -495,6 +516,7 @@ class UsersApi
      *
      * Returns Hangar staff
      *
+     * @param  string $query The search query (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $sort Used to sort the result (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getStaff'] to see the possible values for this operation
@@ -503,9 +525,9 @@ class UsersApi
      * @throws \InvalidArgumentException
      * @return \Aternos\HangarApi\Model\PaginatedResultUser|\Aternos\HangarApi\Model\PaginatedResultUser|\Aternos\HangarApi\Model\PaginatedResultUser
      */
-    public function getStaff($pagination, $sort = null, string $contentType = self::contentTypes['getStaff'][0])
+    public function getStaff($query, $pagination, $sort = null, string $contentType = self::contentTypes['getStaff'][0])
     {
-        list($response) = $this->getStaffWithHttpInfo($pagination, $sort, $contentType);
+        list($response) = $this->getStaffWithHttpInfo($query, $pagination, $sort, $contentType);
         return $response;
     }
 
@@ -514,6 +536,7 @@ class UsersApi
      *
      * Returns Hangar staff
      *
+     * @param  string $query The search query (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $sort Used to sort the result (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getStaff'] to see the possible values for this operation
@@ -522,9 +545,9 @@ class UsersApi
      * @throws \InvalidArgumentException
      * @return array of \Aternos\HangarApi\Model\PaginatedResultUser|\Aternos\HangarApi\Model\PaginatedResultUser|\Aternos\HangarApi\Model\PaginatedResultUser, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getStaffWithHttpInfo($pagination, $sort = null, string $contentType = self::contentTypes['getStaff'][0])
+    public function getStaffWithHttpInfo($query, $pagination, $sort = null, string $contentType = self::contentTypes['getStaff'][0])
     {
-        $request = $this->getStaffRequest($pagination, $sort, $contentType);
+        $request = $this->getStaffRequest($query, $pagination, $sort, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -661,6 +684,7 @@ class UsersApi
      *
      * Returns Hangar staff
      *
+     * @param  string $query The search query (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $sort Used to sort the result (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getStaff'] to see the possible values for this operation
@@ -668,9 +692,9 @@ class UsersApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getStaffAsync($pagination, $sort = null, string $contentType = self::contentTypes['getStaff'][0])
+    public function getStaffAsync($query, $pagination, $sort = null, string $contentType = self::contentTypes['getStaff'][0])
     {
-        return $this->getStaffAsyncWithHttpInfo($pagination, $sort, $contentType)
+        return $this->getStaffAsyncWithHttpInfo($query, $pagination, $sort, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -683,6 +707,7 @@ class UsersApi
      *
      * Returns Hangar staff
      *
+     * @param  string $query The search query (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $sort Used to sort the result (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getStaff'] to see the possible values for this operation
@@ -690,10 +715,10 @@ class UsersApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getStaffAsyncWithHttpInfo($pagination, $sort = null, string $contentType = self::contentTypes['getStaff'][0])
+    public function getStaffAsyncWithHttpInfo($query, $pagination, $sort = null, string $contentType = self::contentTypes['getStaff'][0])
     {
         $returnType = '\Aternos\HangarApi\Model\PaginatedResultUser';
-        $request = $this->getStaffRequest($pagination, $sort, $contentType);
+        $request = $this->getStaffRequest($query, $pagination, $sort, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -734,6 +759,7 @@ class UsersApi
     /**
      * Create request for operation 'getStaff'
      *
+     * @param  string $query The search query (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $sort Used to sort the result (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getStaff'] to see the possible values for this operation
@@ -741,8 +767,15 @@ class UsersApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getStaffRequest($pagination, $sort = null, string $contentType = self::contentTypes['getStaff'][0])
+    public function getStaffRequest($query, $pagination, $sort = null, string $contentType = self::contentTypes['getStaff'][0])
     {
+
+        // verify the required parameter 'query' is set
+        if ($query === null || (is_array($query) && count($query) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $query when calling getStaff'
+            );
+        }
 
         // verify the required parameter 'pagination' is set
         if ($pagination === null || (is_array($pagination) && count($pagination) === 0)) {
@@ -760,6 +793,15 @@ class UsersApi
         $httpBody = '';
         $multipart = false;
 
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $query,
+            'query', // param base name
+            'string', // openApiType
+            'form', // style
+            true, // explode
+            true // required
+        ) ?? []);
         // query params
         $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
             $pagination,

--- a/lib/Api/VersionsApi.php
+++ b/lib/Api/VersionsApi.php
@@ -75,6 +75,30 @@ class VersionsApi
         'downloadVersion' => [
             'application/json',
         ],
+        'downloadVersion1' => [
+            'application/json',
+        ],
+        'getLatestReleaseVersion' => [
+            'application/json',
+        ],
+        'getLatestVersion' => [
+            'application/json',
+        ],
+        'getVersion' => [
+            'application/json',
+        ],
+        'getVersionStats' => [
+            'application/json',
+        ],
+        'getVersions' => [
+            'application/json',
+        ],
+        'latestReleaseVersion' => [
+            'application/json',
+        ],
+        'latestVersion' => [
+            'application/json',
+        ],
         'listVersions' => [
             'application/json',
         ],
@@ -85,6 +109,9 @@ class VersionsApi
             'application/json',
         ],
         'uploadVersion' => [
+            'multipart/form-data',
+        ],
+        'uploadVersion1' => [
             'multipart/form-data',
         ],
     ];
@@ -140,7 +167,6 @@ class VersionsApi
      *
      * Downloads a version
      *
-     * @param  string $author The author of the project to download the version from (required)
      * @param  string $slug The slug of the project to download the version from (required)
      * @param  string $name The name of the version to download (required)
      * @param  string $platform The platform of the version to download (required)
@@ -150,9 +176,9 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \SplFileObject|\SplFileObject|\SplFileObject|\SplFileObject|\SplFileObject
      */
-    public function downloadVersion($author, $slug, $name, $platform, string $contentType = self::contentTypes['downloadVersion'][0])
+    public function downloadVersion($slug, $name, $platform, string $contentType = self::contentTypes['downloadVersion'][0])
     {
-        list($response) = $this->downloadVersionWithHttpInfo($author, $slug, $name, $platform, $contentType);
+        list($response) = $this->downloadVersionWithHttpInfo($slug, $name, $platform, $contentType);
         return $response;
     }
 
@@ -161,7 +187,6 @@ class VersionsApi
      *
      * Downloads a version
      *
-     * @param  string $author The author of the project to download the version from (required)
      * @param  string $slug The slug of the project to download the version from (required)
      * @param  string $name The name of the version to download (required)
      * @param  string $platform The platform of the version to download (required)
@@ -171,9 +196,9 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return array of \SplFileObject|\SplFileObject|\SplFileObject|\SplFileObject|\SplFileObject, HTTP status code, HTTP response headers (array of strings)
      */
-    public function downloadVersionWithHttpInfo($author, $slug, $name, $platform, string $contentType = self::contentTypes['downloadVersion'][0])
+    public function downloadVersionWithHttpInfo($slug, $name, $platform, string $contentType = self::contentTypes['downloadVersion'][0])
     {
-        $request = $this->downloadVersionRequest($author, $slug, $name, $platform, $contentType);
+        $request = $this->downloadVersionRequest($slug, $name, $platform, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -356,7 +381,6 @@ class VersionsApi
      *
      * Downloads a version
      *
-     * @param  string $author The author of the project to download the version from (required)
      * @param  string $slug The slug of the project to download the version from (required)
      * @param  string $name The name of the version to download (required)
      * @param  string $platform The platform of the version to download (required)
@@ -365,9 +389,9 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function downloadVersionAsync($author, $slug, $name, $platform, string $contentType = self::contentTypes['downloadVersion'][0])
+    public function downloadVersionAsync($slug, $name, $platform, string $contentType = self::contentTypes['downloadVersion'][0])
     {
-        return $this->downloadVersionAsyncWithHttpInfo($author, $slug, $name, $platform, $contentType)
+        return $this->downloadVersionAsyncWithHttpInfo($slug, $name, $platform, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -380,7 +404,6 @@ class VersionsApi
      *
      * Downloads a version
      *
-     * @param  string $author The author of the project to download the version from (required)
      * @param  string $slug The slug of the project to download the version from (required)
      * @param  string $name The name of the version to download (required)
      * @param  string $platform The platform of the version to download (required)
@@ -389,10 +412,10 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function downloadVersionAsyncWithHttpInfo($author, $slug, $name, $platform, string $contentType = self::contentTypes['downloadVersion'][0])
+    public function downloadVersionAsyncWithHttpInfo($slug, $name, $platform, string $contentType = self::contentTypes['downloadVersion'][0])
     {
-        $returnType = '\SplFileObject';
-        $request = $this->downloadVersionRequest($author, $slug, $name, $platform, $contentType);
+        $returnType = 'object';
+        $request = $this->downloadVersionRequest($slug, $name, $platform, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -433,7 +456,6 @@ class VersionsApi
     /**
      * Create request for operation 'downloadVersion'
      *
-     * @param  string $author The author of the project to download the version from (required)
      * @param  string $slug The slug of the project to download the version from (required)
      * @param  string $name The name of the version to download (required)
      * @param  string $platform The platform of the version to download (required)
@@ -442,15 +464,8 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function downloadVersionRequest($author, $slug, $name, $platform, string $contentType = self::contentTypes['downloadVersion'][0])
+    public function downloadVersionRequest($slug, $name, $platform, string $contentType = self::contentTypes['downloadVersion'][0])
     {
-
-        // verify the required parameter 'author' is set
-        if ($author === null || (is_array($author) && count($author) === 0)) {
-            throw new \InvalidArgumentException(
-                'Missing the required parameter $author when calling downloadVersion'
-            );
-        }
 
         // verify the required parameter 'slug' is set
         if ($slug === null || (is_array($slug) && count($slug) === 0)) {
@@ -474,7 +489,7 @@ class VersionsApi
         }
 
 
-        $resourcePath = '/api/v1/projects/{author}/{slug}/versions/{name}/{platform}/download';
+        $resourcePath = '/api/v1/projects/{slug}/versions/{name}/{platform}/download';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -483,14 +498,6 @@ class VersionsApi
 
 
 
-        // path params
-        if ($author !== null) {
-            $resourcePath = str_replace(
-                '{' . 'author' . '}',
-                ObjectSerializer::toPathValue($author),
-                $resourcePath
-            );
-        }
         // path params
         if ($slug !== null) {
             $resourcePath = str_replace(
@@ -575,11 +582,2661 @@ class VersionsApi
     }
 
     /**
+     * Operation downloadVersion1
+     *
+     * @param  string $author The author of the project to download the version from (required)
+     * @param  string $slug The slug of the project to download the version from (required)
+     * @param  string $name The name of the version to download (required)
+     * @param  string $platform The platform of the version to download (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['downloadVersion1'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return object
+     * @deprecated
+     */
+    public function downloadVersion1($author, $slug, $name, $platform, string $contentType = self::contentTypes['downloadVersion1'][0])
+    {
+        list($response) = $this->downloadVersion1WithHttpInfo($author, $slug, $name, $platform, $contentType);
+        return $response;
+    }
+
+    /**
+     * Operation downloadVersion1WithHttpInfo
+     *
+     * @param  string $author The author of the project to download the version from (required)
+     * @param  string $slug The slug of the project to download the version from (required)
+     * @param  string $name The name of the version to download (required)
+     * @param  string $platform The platform of the version to download (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['downloadVersion1'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of object, HTTP status code, HTTP response headers (array of strings)
+     * @deprecated
+     */
+    public function downloadVersion1WithHttpInfo($author, $slug, $name, $platform, string $contentType = self::contentTypes['downloadVersion1'][0])
+    {
+        $request = $this->downloadVersion1Request($author, $slug, $name, $platform, $contentType);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                );
+            } catch (ConnectException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    null,
+                    null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        (string) $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    (string) $response->getBody()
+                );
+            }
+
+            switch($statusCode) {
+                case 200:
+                    if ('object' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('object' !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, 'object', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+            $returnType = 'object';
+            if ($returnType === '\SplFileObject') {
+                $content = $response->getBody(); //stream goes to serializer
+            } else {
+                $content = (string) $response->getBody();
+                if ($returnType !== 'string') {
+                    $content = json_decode($content);
+                }
+            }
+
+            return [
+                ObjectSerializer::deserialize($content, $returnType, []),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            ];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        'object',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation downloadVersion1Async
+     *
+     * @param  string $author The author of the project to download the version from (required)
+     * @param  string $slug The slug of the project to download the version from (required)
+     * @param  string $name The name of the version to download (required)
+     * @param  string $platform The platform of the version to download (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['downloadVersion1'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @deprecated
+     */
+    public function downloadVersion1Async($author, $slug, $name, $platform, string $contentType = self::contentTypes['downloadVersion1'][0])
+    {
+        return $this->downloadVersion1AsyncWithHttpInfo($author, $slug, $name, $platform, $contentType)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation downloadVersion1AsyncWithHttpInfo
+     *
+     * @param  string $author The author of the project to download the version from (required)
+     * @param  string $slug The slug of the project to download the version from (required)
+     * @param  string $name The name of the version to download (required)
+     * @param  string $platform The platform of the version to download (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['downloadVersion1'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @deprecated
+     */
+    public function downloadVersion1AsyncWithHttpInfo($author, $slug, $name, $platform, string $contentType = self::contentTypes['downloadVersion1'][0])
+    {
+        $returnType = 'object';
+        $request = $this->downloadVersion1Request($author, $slug, $name, $platform, $contentType);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    if ($returnType === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ($returnType !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'downloadVersion1'
+     *
+     * @param  string $author The author of the project to download the version from (required)
+     * @param  string $slug The slug of the project to download the version from (required)
+     * @param  string $name The name of the version to download (required)
+     * @param  string $platform The platform of the version to download (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['downloadVersion1'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     * @deprecated
+     */
+    public function downloadVersion1Request($author, $slug, $name, $platform, string $contentType = self::contentTypes['downloadVersion1'][0])
+    {
+
+        // verify the required parameter 'author' is set
+        if ($author === null || (is_array($author) && count($author) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $author when calling downloadVersion1'
+            );
+        }
+
+        // verify the required parameter 'slug' is set
+        if ($slug === null || (is_array($slug) && count($slug) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $slug when calling downloadVersion1'
+            );
+        }
+
+        // verify the required parameter 'name' is set
+        if ($name === null || (is_array($name) && count($name) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $name when calling downloadVersion1'
+            );
+        }
+
+        // verify the required parameter 'platform' is set
+        if ($platform === null || (is_array($platform) && count($platform) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $platform when calling downloadVersion1'
+            );
+        }
+
+
+        $resourcePath = '/api/v1/projects/{author}/{slug}/versions/{name}/{platform}/download';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+
+
+        // path params
+        if ($author !== null) {
+            $resourcePath = str_replace(
+                '{' . 'author' . '}',
+                ObjectSerializer::toPathValue($author),
+                $resourcePath
+            );
+        }
+        // path params
+        if ($slug !== null) {
+            $resourcePath = str_replace(
+                '{' . 'slug' . '}',
+                ObjectSerializer::toPathValue($slug),
+                $resourcePath
+            );
+        }
+        // path params
+        if ($name !== null) {
+            $resourcePath = str_replace(
+                '{' . 'name' . '}',
+                ObjectSerializer::toPathValue($name),
+                $resourcePath
+            );
+        }
+        // path params
+        if ($platform !== null) {
+            $resourcePath = str_replace(
+                '{' . 'platform' . '}',
+                ObjectSerializer::toPathValue($platform),
+                $resourcePath
+            );
+        }
+
+
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/octet-stream', ],
+            $contentType,
+            $multipart
+        );
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
+                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = ObjectSerializer::buildQuery($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $operationHost = $this->config->getHost();
+        $query = ObjectSerializer::buildQuery($queryParams);
+        return new Request(
+            'GET',
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Operation getLatestReleaseVersion
+     *
+     * @param  string $author The author of the project to return the latest version for (required)
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getLatestReleaseVersion'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return string
+     * @deprecated
+     */
+    public function getLatestReleaseVersion($author, $slug, string $contentType = self::contentTypes['getLatestReleaseVersion'][0])
+    {
+        list($response) = $this->getLatestReleaseVersionWithHttpInfo($author, $slug, $contentType);
+        return $response;
+    }
+
+    /**
+     * Operation getLatestReleaseVersionWithHttpInfo
+     *
+     * @param  string $author The author of the project to return the latest version for (required)
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getLatestReleaseVersion'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of string, HTTP status code, HTTP response headers (array of strings)
+     * @deprecated
+     */
+    public function getLatestReleaseVersionWithHttpInfo($author, $slug, string $contentType = self::contentTypes['getLatestReleaseVersion'][0])
+    {
+        $request = $this->getLatestReleaseVersionRequest($author, $slug, $contentType);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                );
+            } catch (ConnectException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    null,
+                    null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        (string) $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    (string) $response->getBody()
+                );
+            }
+
+            switch($statusCode) {
+                case 200:
+                    if ('string' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('string' !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, 'string', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+            $returnType = 'string';
+            if ($returnType === '\SplFileObject') {
+                $content = $response->getBody(); //stream goes to serializer
+            } else {
+                $content = (string) $response->getBody();
+                if ($returnType !== 'string') {
+                    $content = json_decode($content);
+                }
+            }
+
+            return [
+                ObjectSerializer::deserialize($content, $returnType, []),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            ];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        'string',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation getLatestReleaseVersionAsync
+     *
+     * @param  string $author The author of the project to return the latest version for (required)
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getLatestReleaseVersion'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @deprecated
+     */
+    public function getLatestReleaseVersionAsync($author, $slug, string $contentType = self::contentTypes['getLatestReleaseVersion'][0])
+    {
+        return $this->getLatestReleaseVersionAsyncWithHttpInfo($author, $slug, $contentType)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation getLatestReleaseVersionAsyncWithHttpInfo
+     *
+     * @param  string $author The author of the project to return the latest version for (required)
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getLatestReleaseVersion'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @deprecated
+     */
+    public function getLatestReleaseVersionAsyncWithHttpInfo($author, $slug, string $contentType = self::contentTypes['getLatestReleaseVersion'][0])
+    {
+        $returnType = 'string';
+        $request = $this->getLatestReleaseVersionRequest($author, $slug, $contentType);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    if ($returnType === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ($returnType !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'getLatestReleaseVersion'
+     *
+     * @param  string $author The author of the project to return the latest version for (required)
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getLatestReleaseVersion'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     * @deprecated
+     */
+    public function getLatestReleaseVersionRequest($author, $slug, string $contentType = self::contentTypes['getLatestReleaseVersion'][0])
+    {
+
+        // verify the required parameter 'author' is set
+        if ($author === null || (is_array($author) && count($author) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $author when calling getLatestReleaseVersion'
+            );
+        }
+
+        // verify the required parameter 'slug' is set
+        if ($slug === null || (is_array($slug) && count($slug) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $slug when calling getLatestReleaseVersion'
+            );
+        }
+
+
+        $resourcePath = '/api/v1/projects/{author}/{slug}/latestrelease';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+
+
+        // path params
+        if ($author !== null) {
+            $resourcePath = str_replace(
+                '{' . 'author' . '}',
+                ObjectSerializer::toPathValue($author),
+                $resourcePath
+            );
+        }
+        // path params
+        if ($slug !== null) {
+            $resourcePath = str_replace(
+                '{' . 'slug' . '}',
+                ObjectSerializer::toPathValue($slug),
+                $resourcePath
+            );
+        }
+
+
+        $headers = $this->headerSelector->selectHeaders(
+            ['text/plain', ],
+            $contentType,
+            $multipart
+        );
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
+                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = ObjectSerializer::buildQuery($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $operationHost = $this->config->getHost();
+        $query = ObjectSerializer::buildQuery($queryParams);
+        return new Request(
+            'GET',
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Operation getLatestVersion
+     *
+     * @param  string $author The author of the project to return the latest version for (required)
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $channel The channel to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getLatestVersion'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return string
+     * @deprecated
+     */
+    public function getLatestVersion($author, $slug, $channel, string $contentType = self::contentTypes['getLatestVersion'][0])
+    {
+        list($response) = $this->getLatestVersionWithHttpInfo($author, $slug, $channel, $contentType);
+        return $response;
+    }
+
+    /**
+     * Operation getLatestVersionWithHttpInfo
+     *
+     * @param  string $author The author of the project to return the latest version for (required)
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $channel The channel to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getLatestVersion'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of string, HTTP status code, HTTP response headers (array of strings)
+     * @deprecated
+     */
+    public function getLatestVersionWithHttpInfo($author, $slug, $channel, string $contentType = self::contentTypes['getLatestVersion'][0])
+    {
+        $request = $this->getLatestVersionRequest($author, $slug, $channel, $contentType);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                );
+            } catch (ConnectException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    null,
+                    null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        (string) $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    (string) $response->getBody()
+                );
+            }
+
+            switch($statusCode) {
+                case 200:
+                    if ('string' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('string' !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, 'string', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+            $returnType = 'string';
+            if ($returnType === '\SplFileObject') {
+                $content = $response->getBody(); //stream goes to serializer
+            } else {
+                $content = (string) $response->getBody();
+                if ($returnType !== 'string') {
+                    $content = json_decode($content);
+                }
+            }
+
+            return [
+                ObjectSerializer::deserialize($content, $returnType, []),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            ];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        'string',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation getLatestVersionAsync
+     *
+     * @param  string $author The author of the project to return the latest version for (required)
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $channel The channel to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getLatestVersion'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @deprecated
+     */
+    public function getLatestVersionAsync($author, $slug, $channel, string $contentType = self::contentTypes['getLatestVersion'][0])
+    {
+        return $this->getLatestVersionAsyncWithHttpInfo($author, $slug, $channel, $contentType)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation getLatestVersionAsyncWithHttpInfo
+     *
+     * @param  string $author The author of the project to return the latest version for (required)
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $channel The channel to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getLatestVersion'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @deprecated
+     */
+    public function getLatestVersionAsyncWithHttpInfo($author, $slug, $channel, string $contentType = self::contentTypes['getLatestVersion'][0])
+    {
+        $returnType = 'string';
+        $request = $this->getLatestVersionRequest($author, $slug, $channel, $contentType);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    if ($returnType === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ($returnType !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'getLatestVersion'
+     *
+     * @param  string $author The author of the project to return the latest version for (required)
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $channel The channel to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getLatestVersion'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     * @deprecated
+     */
+    public function getLatestVersionRequest($author, $slug, $channel, string $contentType = self::contentTypes['getLatestVersion'][0])
+    {
+
+        // verify the required parameter 'author' is set
+        if ($author === null || (is_array($author) && count($author) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $author when calling getLatestVersion'
+            );
+        }
+
+        // verify the required parameter 'slug' is set
+        if ($slug === null || (is_array($slug) && count($slug) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $slug when calling getLatestVersion'
+            );
+        }
+
+        // verify the required parameter 'channel' is set
+        if ($channel === null || (is_array($channel) && count($channel) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $channel when calling getLatestVersion'
+            );
+        }
+
+
+        $resourcePath = '/api/v1/projects/{author}/{slug}/latest';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $channel,
+            'channel', // param base name
+            'string', // openApiType
+            'form', // style
+            true, // explode
+            true // required
+        ) ?? []);
+
+
+        // path params
+        if ($author !== null) {
+            $resourcePath = str_replace(
+                '{' . 'author' . '}',
+                ObjectSerializer::toPathValue($author),
+                $resourcePath
+            );
+        }
+        // path params
+        if ($slug !== null) {
+            $resourcePath = str_replace(
+                '{' . 'slug' . '}',
+                ObjectSerializer::toPathValue($slug),
+                $resourcePath
+            );
+        }
+
+
+        $headers = $this->headerSelector->selectHeaders(
+            ['text/plain', ],
+            $contentType,
+            $multipart
+        );
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
+                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = ObjectSerializer::buildQuery($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $operationHost = $this->config->getHost();
+        $query = ObjectSerializer::buildQuery($queryParams);
+        return new Request(
+            'GET',
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Operation getVersion
+     *
+     * @param  string $author The author of the project to return the version for (required)
+     * @param  string $slug The slug of the project to return the version for (required)
+     * @param  string $name The name of the version to return (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getVersion'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return \Aternos\HangarApi\Model\Version
+     * @deprecated
+     */
+    public function getVersion($author, $slug, $name, string $contentType = self::contentTypes['getVersion'][0])
+    {
+        list($response) = $this->getVersionWithHttpInfo($author, $slug, $name, $contentType);
+        return $response;
+    }
+
+    /**
+     * Operation getVersionWithHttpInfo
+     *
+     * @param  string $author The author of the project to return the version for (required)
+     * @param  string $slug The slug of the project to return the version for (required)
+     * @param  string $name The name of the version to return (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getVersion'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of \Aternos\HangarApi\Model\Version, HTTP status code, HTTP response headers (array of strings)
+     * @deprecated
+     */
+    public function getVersionWithHttpInfo($author, $slug, $name, string $contentType = self::contentTypes['getVersion'][0])
+    {
+        $request = $this->getVersionRequest($author, $slug, $name, $contentType);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                );
+            } catch (ConnectException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    null,
+                    null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        (string) $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    (string) $response->getBody()
+                );
+            }
+
+            switch($statusCode) {
+                case 200:
+                    if ('\Aternos\HangarApi\Model\Version' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('\Aternos\HangarApi\Model\Version' !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\Aternos\HangarApi\Model\Version', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+            $returnType = '\Aternos\HangarApi\Model\Version';
+            if ($returnType === '\SplFileObject') {
+                $content = $response->getBody(); //stream goes to serializer
+            } else {
+                $content = (string) $response->getBody();
+                if ($returnType !== 'string') {
+                    $content = json_decode($content);
+                }
+            }
+
+            return [
+                ObjectSerializer::deserialize($content, $returnType, []),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            ];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\Aternos\HangarApi\Model\Version',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation getVersionAsync
+     *
+     * @param  string $author The author of the project to return the version for (required)
+     * @param  string $slug The slug of the project to return the version for (required)
+     * @param  string $name The name of the version to return (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getVersion'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @deprecated
+     */
+    public function getVersionAsync($author, $slug, $name, string $contentType = self::contentTypes['getVersion'][0])
+    {
+        return $this->getVersionAsyncWithHttpInfo($author, $slug, $name, $contentType)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation getVersionAsyncWithHttpInfo
+     *
+     * @param  string $author The author of the project to return the version for (required)
+     * @param  string $slug The slug of the project to return the version for (required)
+     * @param  string $name The name of the version to return (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getVersion'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @deprecated
+     */
+    public function getVersionAsyncWithHttpInfo($author, $slug, $name, string $contentType = self::contentTypes['getVersion'][0])
+    {
+        $returnType = '\Aternos\HangarApi\Model\Version';
+        $request = $this->getVersionRequest($author, $slug, $name, $contentType);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    if ($returnType === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ($returnType !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'getVersion'
+     *
+     * @param  string $author The author of the project to return the version for (required)
+     * @param  string $slug The slug of the project to return the version for (required)
+     * @param  string $name The name of the version to return (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getVersion'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     * @deprecated
+     */
+    public function getVersionRequest($author, $slug, $name, string $contentType = self::contentTypes['getVersion'][0])
+    {
+
+        // verify the required parameter 'author' is set
+        if ($author === null || (is_array($author) && count($author) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $author when calling getVersion'
+            );
+        }
+
+        // verify the required parameter 'slug' is set
+        if ($slug === null || (is_array($slug) && count($slug) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $slug when calling getVersion'
+            );
+        }
+
+        // verify the required parameter 'name' is set
+        if ($name === null || (is_array($name) && count($name) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $name when calling getVersion'
+            );
+        }
+
+
+        $resourcePath = '/api/v1/projects/{author}/{slug}/versions/{name}';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+
+
+        // path params
+        if ($author !== null) {
+            $resourcePath = str_replace(
+                '{' . 'author' . '}',
+                ObjectSerializer::toPathValue($author),
+                $resourcePath
+            );
+        }
+        // path params
+        if ($slug !== null) {
+            $resourcePath = str_replace(
+                '{' . 'slug' . '}',
+                ObjectSerializer::toPathValue($slug),
+                $resourcePath
+            );
+        }
+        // path params
+        if ($name !== null) {
+            $resourcePath = str_replace(
+                '{' . 'name' . '}',
+                ObjectSerializer::toPathValue($name),
+                $resourcePath
+            );
+        }
+
+
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/json', ],
+            $contentType,
+            $multipart
+        );
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
+                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = ObjectSerializer::buildQuery($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $operationHost = $this->config->getHost();
+        $query = ObjectSerializer::buildQuery($queryParams);
+        return new Request(
+            'GET',
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Operation getVersionStats
+     *
+     * @param  string $author The author of the version to return the stats for (required)
+     * @param  string $slug The slug of the project to return stats for (required)
+     * @param  string $name The version to return the stats for (required)
+     * @param  \DateTime $from_date The first date to include in the result (required)
+     * @param  \DateTime $to_date The last date to include in the result (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getVersionStats'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array<string,\Aternos\HangarApi\Model\VersionStats>
+     * @deprecated
+     */
+    public function getVersionStats($author, $slug, $name, $from_date, $to_date, string $contentType = self::contentTypes['getVersionStats'][0])
+    {
+        list($response) = $this->getVersionStatsWithHttpInfo($author, $slug, $name, $from_date, $to_date, $contentType);
+        return $response;
+    }
+
+    /**
+     * Operation getVersionStatsWithHttpInfo
+     *
+     * @param  string $author The author of the version to return the stats for (required)
+     * @param  string $slug The slug of the project to return stats for (required)
+     * @param  string $name The version to return the stats for (required)
+     * @param  \DateTime $from_date The first date to include in the result (required)
+     * @param  \DateTime $to_date The last date to include in the result (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getVersionStats'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of array<string,\Aternos\HangarApi\Model\VersionStats>, HTTP status code, HTTP response headers (array of strings)
+     * @deprecated
+     */
+    public function getVersionStatsWithHttpInfo($author, $slug, $name, $from_date, $to_date, string $contentType = self::contentTypes['getVersionStats'][0])
+    {
+        $request = $this->getVersionStatsRequest($author, $slug, $name, $from_date, $to_date, $contentType);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                );
+            } catch (ConnectException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    null,
+                    null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        (string) $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    (string) $response->getBody()
+                );
+            }
+
+            switch($statusCode) {
+                case 200:
+                    if ('array<string,\Aternos\HangarApi\Model\VersionStats>' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('array<string,\Aternos\HangarApi\Model\VersionStats>' !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, 'array<string,\Aternos\HangarApi\Model\VersionStats>', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+            $returnType = 'array<string,\Aternos\HangarApi\Model\VersionStats>';
+            if ($returnType === '\SplFileObject') {
+                $content = $response->getBody(); //stream goes to serializer
+            } else {
+                $content = (string) $response->getBody();
+                if ($returnType !== 'string') {
+                    $content = json_decode($content);
+                }
+            }
+
+            return [
+                ObjectSerializer::deserialize($content, $returnType, []),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            ];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        'array<string,\Aternos\HangarApi\Model\VersionStats>',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation getVersionStatsAsync
+     *
+     * @param  string $author The author of the version to return the stats for (required)
+     * @param  string $slug The slug of the project to return stats for (required)
+     * @param  string $name The version to return the stats for (required)
+     * @param  \DateTime $from_date The first date to include in the result (required)
+     * @param  \DateTime $to_date The last date to include in the result (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getVersionStats'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @deprecated
+     */
+    public function getVersionStatsAsync($author, $slug, $name, $from_date, $to_date, string $contentType = self::contentTypes['getVersionStats'][0])
+    {
+        return $this->getVersionStatsAsyncWithHttpInfo($author, $slug, $name, $from_date, $to_date, $contentType)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation getVersionStatsAsyncWithHttpInfo
+     *
+     * @param  string $author The author of the version to return the stats for (required)
+     * @param  string $slug The slug of the project to return stats for (required)
+     * @param  string $name The version to return the stats for (required)
+     * @param  \DateTime $from_date The first date to include in the result (required)
+     * @param  \DateTime $to_date The last date to include in the result (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getVersionStats'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @deprecated
+     */
+    public function getVersionStatsAsyncWithHttpInfo($author, $slug, $name, $from_date, $to_date, string $contentType = self::contentTypes['getVersionStats'][0])
+    {
+        $returnType = 'array<string,\Aternos\HangarApi\Model\VersionStats>';
+        $request = $this->getVersionStatsRequest($author, $slug, $name, $from_date, $to_date, $contentType);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    if ($returnType === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ($returnType !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'getVersionStats'
+     *
+     * @param  string $author The author of the version to return the stats for (required)
+     * @param  string $slug The slug of the project to return stats for (required)
+     * @param  string $name The version to return the stats for (required)
+     * @param  \DateTime $from_date The first date to include in the result (required)
+     * @param  \DateTime $to_date The last date to include in the result (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getVersionStats'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     * @deprecated
+     */
+    public function getVersionStatsRequest($author, $slug, $name, $from_date, $to_date, string $contentType = self::contentTypes['getVersionStats'][0])
+    {
+
+        // verify the required parameter 'author' is set
+        if ($author === null || (is_array($author) && count($author) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $author when calling getVersionStats'
+            );
+        }
+
+        // verify the required parameter 'slug' is set
+        if ($slug === null || (is_array($slug) && count($slug) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $slug when calling getVersionStats'
+            );
+        }
+
+        // verify the required parameter 'name' is set
+        if ($name === null || (is_array($name) && count($name) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $name when calling getVersionStats'
+            );
+        }
+
+        // verify the required parameter 'from_date' is set
+        if ($from_date === null || (is_array($from_date) && count($from_date) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $from_date when calling getVersionStats'
+            );
+        }
+
+        // verify the required parameter 'to_date' is set
+        if ($to_date === null || (is_array($to_date) && count($to_date) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $to_date when calling getVersionStats'
+            );
+        }
+
+
+        $resourcePath = '/api/v1/projects/{author}/{slug}/versions/{name}/stats';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $from_date,
+            'fromDate', // param base name
+            'string', // openApiType
+            'form', // style
+            true, // explode
+            true // required
+        ) ?? []);
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $to_date,
+            'toDate', // param base name
+            'string', // openApiType
+            'form', // style
+            true, // explode
+            true // required
+        ) ?? []);
+
+
+        // path params
+        if ($author !== null) {
+            $resourcePath = str_replace(
+                '{' . 'author' . '}',
+                ObjectSerializer::toPathValue($author),
+                $resourcePath
+            );
+        }
+        // path params
+        if ($slug !== null) {
+            $resourcePath = str_replace(
+                '{' . 'slug' . '}',
+                ObjectSerializer::toPathValue($slug),
+                $resourcePath
+            );
+        }
+        // path params
+        if ($name !== null) {
+            $resourcePath = str_replace(
+                '{' . 'name' . '}',
+                ObjectSerializer::toPathValue($name),
+                $resourcePath
+            );
+        }
+
+
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/json', ],
+            $contentType,
+            $multipart
+        );
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
+                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = ObjectSerializer::buildQuery($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $operationHost = $this->config->getHost();
+        $query = ObjectSerializer::buildQuery($queryParams);
+        return new Request(
+            'GET',
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Operation getVersions
+     *
+     * @param  string $author The author of the project to return versions for (required)
+     * @param  string $slug The slug of the project to return versions for (required)
+     * @param  RequestPagination $pagination Pagination information (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getVersions'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return \Aternos\HangarApi\Model\PaginatedResultVersion
+     * @deprecated
+     */
+    public function getVersions($author, $slug, $pagination, string $contentType = self::contentTypes['getVersions'][0])
+    {
+        list($response) = $this->getVersionsWithHttpInfo($author, $slug, $pagination, $contentType);
+        return $response;
+    }
+
+    /**
+     * Operation getVersionsWithHttpInfo
+     *
+     * @param  string $author The author of the project to return versions for (required)
+     * @param  string $slug The slug of the project to return versions for (required)
+     * @param  RequestPagination $pagination Pagination information (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getVersions'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of \Aternos\HangarApi\Model\PaginatedResultVersion, HTTP status code, HTTP response headers (array of strings)
+     * @deprecated
+     */
+    public function getVersionsWithHttpInfo($author, $slug, $pagination, string $contentType = self::contentTypes['getVersions'][0])
+    {
+        $request = $this->getVersionsRequest($author, $slug, $pagination, $contentType);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                );
+            } catch (ConnectException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    null,
+                    null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        (string) $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    (string) $response->getBody()
+                );
+            }
+
+            switch($statusCode) {
+                case 200:
+                    if ('\Aternos\HangarApi\Model\PaginatedResultVersion' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('\Aternos\HangarApi\Model\PaginatedResultVersion' !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\Aternos\HangarApi\Model\PaginatedResultVersion', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+            $returnType = '\Aternos\HangarApi\Model\PaginatedResultVersion';
+            if ($returnType === '\SplFileObject') {
+                $content = $response->getBody(); //stream goes to serializer
+            } else {
+                $content = (string) $response->getBody();
+                if ($returnType !== 'string') {
+                    $content = json_decode($content);
+                }
+            }
+
+            return [
+                ObjectSerializer::deserialize($content, $returnType, []),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            ];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\Aternos\HangarApi\Model\PaginatedResultVersion',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation getVersionsAsync
+     *
+     * @param  string $author The author of the project to return versions for (required)
+     * @param  string $slug The slug of the project to return versions for (required)
+     * @param  RequestPagination $pagination Pagination information (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getVersions'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @deprecated
+     */
+    public function getVersionsAsync($author, $slug, $pagination, string $contentType = self::contentTypes['getVersions'][0])
+    {
+        return $this->getVersionsAsyncWithHttpInfo($author, $slug, $pagination, $contentType)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation getVersionsAsyncWithHttpInfo
+     *
+     * @param  string $author The author of the project to return versions for (required)
+     * @param  string $slug The slug of the project to return versions for (required)
+     * @param  RequestPagination $pagination Pagination information (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getVersions'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @deprecated
+     */
+    public function getVersionsAsyncWithHttpInfo($author, $slug, $pagination, string $contentType = self::contentTypes['getVersions'][0])
+    {
+        $returnType = '\Aternos\HangarApi\Model\PaginatedResultVersion';
+        $request = $this->getVersionsRequest($author, $slug, $pagination, $contentType);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    if ($returnType === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ($returnType !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'getVersions'
+     *
+     * @param  string $author The author of the project to return versions for (required)
+     * @param  string $slug The slug of the project to return versions for (required)
+     * @param  RequestPagination $pagination Pagination information (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getVersions'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     * @deprecated
+     */
+    public function getVersionsRequest($author, $slug, $pagination, string $contentType = self::contentTypes['getVersions'][0])
+    {
+
+        // verify the required parameter 'author' is set
+        if ($author === null || (is_array($author) && count($author) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $author when calling getVersions'
+            );
+        }
+
+        // verify the required parameter 'slug' is set
+        if ($slug === null || (is_array($slug) && count($slug) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $slug when calling getVersions'
+            );
+        }
+
+        // verify the required parameter 'pagination' is set
+        if ($pagination === null || (is_array($pagination) && count($pagination) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $pagination when calling getVersions'
+            );
+        }
+
+
+        $resourcePath = '/api/v1/projects/{author}/{slug}/versions';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $pagination,
+            'pagination', // param base name
+            'object', // openApiType
+            'form', // style
+            true, // explode
+            true // required
+        ) ?? []);
+
+
+        // path params
+        if ($author !== null) {
+            $resourcePath = str_replace(
+                '{' . 'author' . '}',
+                ObjectSerializer::toPathValue($author),
+                $resourcePath
+            );
+        }
+        // path params
+        if ($slug !== null) {
+            $resourcePath = str_replace(
+                '{' . 'slug' . '}',
+                ObjectSerializer::toPathValue($slug),
+                $resourcePath
+            );
+        }
+
+
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/json', ],
+            $contentType,
+            $multipart
+        );
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
+                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = ObjectSerializer::buildQuery($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $operationHost = $this->config->getHost();
+        $query = ObjectSerializer::buildQuery($queryParams);
+        return new Request(
+            'GET',
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Operation latestReleaseVersion
+     *
+     * Returns the latest release version of a project
+     *
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['latestReleaseVersion'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return string|string|string
+     */
+    public function latestReleaseVersion($slug, string $contentType = self::contentTypes['latestReleaseVersion'][0])
+    {
+        list($response) = $this->latestReleaseVersionWithHttpInfo($slug, $contentType);
+        return $response;
+    }
+
+    /**
+     * Operation latestReleaseVersionWithHttpInfo
+     *
+     * Returns the latest release version of a project
+     *
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['latestReleaseVersion'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of string|string|string, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function latestReleaseVersionWithHttpInfo($slug, string $contentType = self::contentTypes['latestReleaseVersion'][0])
+    {
+        $request = $this->latestReleaseVersionRequest($slug, $contentType);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                );
+            } catch (ConnectException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    null,
+                    null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        (string) $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    (string) $response->getBody()
+                );
+            }
+
+            switch($statusCode) {
+                case 200:
+                    if ('string' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('string' !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, 'string', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 403:
+                    if ('string' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('string' !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, 'string', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 401:
+                    if ('string' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('string' !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, 'string', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+            $returnType = 'string';
+            if ($returnType === '\SplFileObject') {
+                $content = $response->getBody(); //stream goes to serializer
+            } else {
+                $content = (string) $response->getBody();
+                if ($returnType !== 'string') {
+                    $content = json_decode($content);
+                }
+            }
+
+            return [
+                ObjectSerializer::deserialize($content, $returnType, []),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            ];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        'string',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+                case 403:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        'string',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+                case 401:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        'string',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation latestReleaseVersionAsync
+     *
+     * Returns the latest release version of a project
+     *
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['latestReleaseVersion'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function latestReleaseVersionAsync($slug, string $contentType = self::contentTypes['latestReleaseVersion'][0])
+    {
+        return $this->latestReleaseVersionAsyncWithHttpInfo($slug, $contentType)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation latestReleaseVersionAsyncWithHttpInfo
+     *
+     * Returns the latest release version of a project
+     *
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['latestReleaseVersion'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function latestReleaseVersionAsyncWithHttpInfo($slug, string $contentType = self::contentTypes['latestReleaseVersion'][0])
+    {
+        $returnType = 'string';
+        $request = $this->latestReleaseVersionRequest($slug, $contentType);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    if ($returnType === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ($returnType !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'latestReleaseVersion'
+     *
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['latestReleaseVersion'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    public function latestReleaseVersionRequest($slug, string $contentType = self::contentTypes['latestReleaseVersion'][0])
+    {
+
+        // verify the required parameter 'slug' is set
+        if ($slug === null || (is_array($slug) && count($slug) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $slug when calling latestReleaseVersion'
+            );
+        }
+
+
+        $resourcePath = '/api/v1/projects/{slug}/latestrelease';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+
+
+        // path params
+        if ($slug !== null) {
+            $resourcePath = str_replace(
+                '{' . 'slug' . '}',
+                ObjectSerializer::toPathValue($slug),
+                $resourcePath
+            );
+        }
+
+
+        $headers = $this->headerSelector->selectHeaders(
+            ['text/plain', ],
+            $contentType,
+            $multipart
+        );
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
+                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = ObjectSerializer::buildQuery($formParams);
+            }
+        }
+
+        // this endpoint requires Bearer (JWT) authentication (access token)
+        if (!empty($this->config->getAccessToken())) {
+            $headers['Authorization'] = 'Bearer ' . $this->config->getAccessToken();
+        }
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $operationHost = $this->config->getHost();
+        $query = ObjectSerializer::buildQuery($queryParams);
+        return new Request(
+            'GET',
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Operation latestVersion
+     *
+     * Returns the latest version of a project for a specific channel
+     *
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $channel The channel to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['latestVersion'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return string|string|string
+     */
+    public function latestVersion($slug, $channel, string $contentType = self::contentTypes['latestVersion'][0])
+    {
+        list($response) = $this->latestVersionWithHttpInfo($slug, $channel, $contentType);
+        return $response;
+    }
+
+    /**
+     * Operation latestVersionWithHttpInfo
+     *
+     * Returns the latest version of a project for a specific channel
+     *
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $channel The channel to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['latestVersion'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of string|string|string, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function latestVersionWithHttpInfo($slug, $channel, string $contentType = self::contentTypes['latestVersion'][0])
+    {
+        $request = $this->latestVersionRequest($slug, $channel, $contentType);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                );
+            } catch (ConnectException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    null,
+                    null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        (string) $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    (string) $response->getBody()
+                );
+            }
+
+            switch($statusCode) {
+                case 200:
+                    if ('string' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('string' !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, 'string', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 403:
+                    if ('string' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('string' !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, 'string', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 401:
+                    if ('string' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('string' !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, 'string', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+            $returnType = 'string';
+            if ($returnType === '\SplFileObject') {
+                $content = $response->getBody(); //stream goes to serializer
+            } else {
+                $content = (string) $response->getBody();
+                if ($returnType !== 'string') {
+                    $content = json_decode($content);
+                }
+            }
+
+            return [
+                ObjectSerializer::deserialize($content, $returnType, []),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            ];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        'string',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+                case 403:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        'string',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+                case 401:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        'string',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation latestVersionAsync
+     *
+     * Returns the latest version of a project for a specific channel
+     *
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $channel The channel to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['latestVersion'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function latestVersionAsync($slug, $channel, string $contentType = self::contentTypes['latestVersion'][0])
+    {
+        return $this->latestVersionAsyncWithHttpInfo($slug, $channel, $contentType)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation latestVersionAsyncWithHttpInfo
+     *
+     * Returns the latest version of a project for a specific channel
+     *
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $channel The channel to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['latestVersion'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function latestVersionAsyncWithHttpInfo($slug, $channel, string $contentType = self::contentTypes['latestVersion'][0])
+    {
+        $returnType = 'string';
+        $request = $this->latestVersionRequest($slug, $channel, $contentType);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    if ($returnType === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ($returnType !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'latestVersion'
+     *
+     * @param  string $slug The slug of the project to return the latest version for (required)
+     * @param  string $channel The channel to return the latest version for (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['latestVersion'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    public function latestVersionRequest($slug, $channel, string $contentType = self::contentTypes['latestVersion'][0])
+    {
+
+        // verify the required parameter 'slug' is set
+        if ($slug === null || (is_array($slug) && count($slug) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $slug when calling latestVersion'
+            );
+        }
+
+        // verify the required parameter 'channel' is set
+        if ($channel === null || (is_array($channel) && count($channel) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $channel when calling latestVersion'
+            );
+        }
+
+
+        $resourcePath = '/api/v1/projects/{slug}/latest';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $channel,
+            'channel', // param base name
+            'string', // openApiType
+            'form', // style
+            true, // explode
+            true // required
+        ) ?? []);
+
+
+        // path params
+        if ($slug !== null) {
+            $resourcePath = str_replace(
+                '{' . 'slug' . '}',
+                ObjectSerializer::toPathValue($slug),
+                $resourcePath
+            );
+        }
+
+
+        $headers = $this->headerSelector->selectHeaders(
+            ['text/plain', ],
+            $contentType,
+            $multipart
+        );
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
+                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = ObjectSerializer::buildQuery($formParams);
+            }
+        }
+
+        // this endpoint requires Bearer (JWT) authentication (access token)
+        if (!empty($this->config->getAccessToken())) {
+            $headers['Authorization'] = 'Bearer ' . $this->config->getAccessToken();
+        }
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $operationHost = $this->config->getHost();
+        $query = ObjectSerializer::buildQuery($queryParams);
+        return new Request(
+            'GET',
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
      * Operation listVersions
      *
      * Returns all versions of a project
      *
-     * @param  string $author The author of the project to return versions for (required)
      * @param  string $slug The slug of the project to return versions for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $channel A name of a version channel to filter for (optional)
@@ -591,9 +3248,9 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \Aternos\HangarApi\Model\PaginatedResultVersion|\Aternos\HangarApi\Model\PaginatedResultVersion|\Aternos\HangarApi\Model\PaginatedResultVersion
      */
-    public function listVersions($author, $slug, $pagination, $channel = null, $platform = null, $platform_version = null, string $contentType = self::contentTypes['listVersions'][0])
+    public function listVersions($slug, $pagination, $channel = null, $platform = null, $platform_version = null, string $contentType = self::contentTypes['listVersions'][0])
     {
-        list($response) = $this->listVersionsWithHttpInfo($author, $slug, $pagination, $channel, $platform, $platform_version, $contentType);
+        list($response) = $this->listVersionsWithHttpInfo($slug, $pagination, $channel, $platform, $platform_version, $contentType);
         return $response;
     }
 
@@ -602,7 +3259,6 @@ class VersionsApi
      *
      * Returns all versions of a project
      *
-     * @param  string $author The author of the project to return versions for (required)
      * @param  string $slug The slug of the project to return versions for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $channel A name of a version channel to filter for (optional)
@@ -614,9 +3270,9 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return array of \Aternos\HangarApi\Model\PaginatedResultVersion|\Aternos\HangarApi\Model\PaginatedResultVersion|\Aternos\HangarApi\Model\PaginatedResultVersion, HTTP status code, HTTP response headers (array of strings)
      */
-    public function listVersionsWithHttpInfo($author, $slug, $pagination, $channel = null, $platform = null, $platform_version = null, string $contentType = self::contentTypes['listVersions'][0])
+    public function listVersionsWithHttpInfo($slug, $pagination, $channel = null, $platform = null, $platform_version = null, string $contentType = self::contentTypes['listVersions'][0])
     {
-        $request = $this->listVersionsRequest($author, $slug, $pagination, $channel, $platform, $platform_version, $contentType);
+        $request = $this->listVersionsRequest($slug, $pagination, $channel, $platform, $platform_version, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -753,7 +3409,6 @@ class VersionsApi
      *
      * Returns all versions of a project
      *
-     * @param  string $author The author of the project to return versions for (required)
      * @param  string $slug The slug of the project to return versions for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $channel A name of a version channel to filter for (optional)
@@ -764,9 +3419,9 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function listVersionsAsync($author, $slug, $pagination, $channel = null, $platform = null, $platform_version = null, string $contentType = self::contentTypes['listVersions'][0])
+    public function listVersionsAsync($slug, $pagination, $channel = null, $platform = null, $platform_version = null, string $contentType = self::contentTypes['listVersions'][0])
     {
-        return $this->listVersionsAsyncWithHttpInfo($author, $slug, $pagination, $channel, $platform, $platform_version, $contentType)
+        return $this->listVersionsAsyncWithHttpInfo($slug, $pagination, $channel, $platform, $platform_version, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -779,7 +3434,6 @@ class VersionsApi
      *
      * Returns all versions of a project
      *
-     * @param  string $author The author of the project to return versions for (required)
      * @param  string $slug The slug of the project to return versions for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $channel A name of a version channel to filter for (optional)
@@ -790,10 +3444,10 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function listVersionsAsyncWithHttpInfo($author, $slug, $pagination, $channel = null, $platform = null, $platform_version = null, string $contentType = self::contentTypes['listVersions'][0])
+    public function listVersionsAsyncWithHttpInfo($slug, $pagination, $channel = null, $platform = null, $platform_version = null, string $contentType = self::contentTypes['listVersions'][0])
     {
         $returnType = '\Aternos\HangarApi\Model\PaginatedResultVersion';
-        $request = $this->listVersionsRequest($author, $slug, $pagination, $channel, $platform, $platform_version, $contentType);
+        $request = $this->listVersionsRequest($slug, $pagination, $channel, $platform, $platform_version, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -834,7 +3488,6 @@ class VersionsApi
     /**
      * Create request for operation 'listVersions'
      *
-     * @param  string $author The author of the project to return versions for (required)
      * @param  string $slug The slug of the project to return versions for (required)
      * @param  RequestPagination $pagination Pagination information (required)
      * @param  string $channel A name of a version channel to filter for (optional)
@@ -845,15 +3498,8 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function listVersionsRequest($author, $slug, $pagination, $channel = null, $platform = null, $platform_version = null, string $contentType = self::contentTypes['listVersions'][0])
+    public function listVersionsRequest($slug, $pagination, $channel = null, $platform = null, $platform_version = null, string $contentType = self::contentTypes['listVersions'][0])
     {
-
-        // verify the required parameter 'author' is set
-        if ($author === null || (is_array($author) && count($author) === 0)) {
-            throw new \InvalidArgumentException(
-                'Missing the required parameter $author when calling listVersions'
-            );
-        }
 
         // verify the required parameter 'slug' is set
         if ($slug === null || (is_array($slug) && count($slug) === 0)) {
@@ -873,7 +3519,7 @@ class VersionsApi
 
 
 
-        $resourcePath = '/api/v1/projects/{author}/{slug}/versions';
+        $resourcePath = '/api/v1/projects/{slug}/versions';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -918,14 +3564,6 @@ class VersionsApi
         ) ?? []);
 
 
-        // path params
-        if ($author !== null) {
-            $resourcePath = str_replace(
-                '{' . 'author' . '}',
-                ObjectSerializer::toPathValue($author),
-                $resourcePath
-            );
-        }
         // path params
         if ($slug !== null) {
             $resourcePath = str_replace(
@@ -998,7 +3636,6 @@ class VersionsApi
      *
      * Returns a specific version of a project
      *
-     * @param  string $author The author of the project to return the version for (required)
      * @param  string $slug The slug of the project to return the version for (required)
      * @param  string $name The name of the version to return (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['showVersion'] to see the possible values for this operation
@@ -1007,9 +3644,9 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \Aternos\HangarApi\Model\Version|\Aternos\HangarApi\Model\Version|\Aternos\HangarApi\Model\Version
      */
-    public function showVersion($author, $slug, $name, string $contentType = self::contentTypes['showVersion'][0])
+    public function showVersion($slug, $name, string $contentType = self::contentTypes['showVersion'][0])
     {
-        list($response) = $this->showVersionWithHttpInfo($author, $slug, $name, $contentType);
+        list($response) = $this->showVersionWithHttpInfo($slug, $name, $contentType);
         return $response;
     }
 
@@ -1018,7 +3655,6 @@ class VersionsApi
      *
      * Returns a specific version of a project
      *
-     * @param  string $author The author of the project to return the version for (required)
      * @param  string $slug The slug of the project to return the version for (required)
      * @param  string $name The name of the version to return (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['showVersion'] to see the possible values for this operation
@@ -1027,9 +3663,9 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return array of \Aternos\HangarApi\Model\Version|\Aternos\HangarApi\Model\Version|\Aternos\HangarApi\Model\Version, HTTP status code, HTTP response headers (array of strings)
      */
-    public function showVersionWithHttpInfo($author, $slug, $name, string $contentType = self::contentTypes['showVersion'][0])
+    public function showVersionWithHttpInfo($slug, $name, string $contentType = self::contentTypes['showVersion'][0])
     {
-        $request = $this->showVersionRequest($author, $slug, $name, $contentType);
+        $request = $this->showVersionRequest($slug, $name, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1166,7 +3802,6 @@ class VersionsApi
      *
      * Returns a specific version of a project
      *
-     * @param  string $author The author of the project to return the version for (required)
      * @param  string $slug The slug of the project to return the version for (required)
      * @param  string $name The name of the version to return (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['showVersion'] to see the possible values for this operation
@@ -1174,9 +3809,9 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function showVersionAsync($author, $slug, $name, string $contentType = self::contentTypes['showVersion'][0])
+    public function showVersionAsync($slug, $name, string $contentType = self::contentTypes['showVersion'][0])
     {
-        return $this->showVersionAsyncWithHttpInfo($author, $slug, $name, $contentType)
+        return $this->showVersionAsyncWithHttpInfo($slug, $name, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1189,7 +3824,6 @@ class VersionsApi
      *
      * Returns a specific version of a project
      *
-     * @param  string $author The author of the project to return the version for (required)
      * @param  string $slug The slug of the project to return the version for (required)
      * @param  string $name The name of the version to return (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['showVersion'] to see the possible values for this operation
@@ -1197,10 +3831,10 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function showVersionAsyncWithHttpInfo($author, $slug, $name, string $contentType = self::contentTypes['showVersion'][0])
+    public function showVersionAsyncWithHttpInfo($slug, $name, string $contentType = self::contentTypes['showVersion'][0])
     {
         $returnType = '\Aternos\HangarApi\Model\Version';
-        $request = $this->showVersionRequest($author, $slug, $name, $contentType);
+        $request = $this->showVersionRequest($slug, $name, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1241,7 +3875,6 @@ class VersionsApi
     /**
      * Create request for operation 'showVersion'
      *
-     * @param  string $author The author of the project to return the version for (required)
      * @param  string $slug The slug of the project to return the version for (required)
      * @param  string $name The name of the version to return (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['showVersion'] to see the possible values for this operation
@@ -1249,15 +3882,8 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function showVersionRequest($author, $slug, $name, string $contentType = self::contentTypes['showVersion'][0])
+    public function showVersionRequest($slug, $name, string $contentType = self::contentTypes['showVersion'][0])
     {
-
-        // verify the required parameter 'author' is set
-        if ($author === null || (is_array($author) && count($author) === 0)) {
-            throw new \InvalidArgumentException(
-                'Missing the required parameter $author when calling showVersion'
-            );
-        }
 
         // verify the required parameter 'slug' is set
         if ($slug === null || (is_array($slug) && count($slug) === 0)) {
@@ -1274,7 +3900,7 @@ class VersionsApi
         }
 
 
-        $resourcePath = '/api/v1/projects/{author}/{slug}/versions/{name}';
+        $resourcePath = '/api/v1/projects/{slug}/versions/{name}';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -1283,14 +3909,6 @@ class VersionsApi
 
 
 
-        // path params
-        if ($author !== null) {
-            $resourcePath = str_replace(
-                '{' . 'author' . '}',
-                ObjectSerializer::toPathValue($author),
-                $resourcePath
-            );
-        }
         // path params
         if ($slug !== null) {
             $resourcePath = str_replace(
@@ -1371,7 +3989,6 @@ class VersionsApi
      *
      * Returns the stats for a version
      *
-     * @param  string $author The author of the version to return the stats for (required)
      * @param  string $slug The slug of the project to return stats for (required)
      * @param  string $name The version to return the stats for (required)
      * @param  string $from_date The first date to include in the result (required)
@@ -1382,9 +3999,9 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return array<string,\Aternos\HangarApi\Model\VersionStats>|array<string,\Aternos\HangarApi\Model\VersionStats>|array<string,\Aternos\HangarApi\Model\VersionStats>
      */
-    public function showVersionStats($author, $slug, $name, $from_date, $to_date, string $contentType = self::contentTypes['showVersionStats'][0])
+    public function showVersionStats($slug, $name, $from_date, $to_date, string $contentType = self::contentTypes['showVersionStats'][0])
     {
-        list($response) = $this->showVersionStatsWithHttpInfo($author, $slug, $name, $from_date, $to_date, $contentType);
+        list($response) = $this->showVersionStatsWithHttpInfo($slug, $name, $from_date, $to_date, $contentType);
         return $response;
     }
 
@@ -1393,7 +4010,6 @@ class VersionsApi
      *
      * Returns the stats for a version
      *
-     * @param  string $author The author of the version to return the stats for (required)
      * @param  string $slug The slug of the project to return stats for (required)
      * @param  string $name The version to return the stats for (required)
      * @param  string $from_date The first date to include in the result (required)
@@ -1404,9 +4020,9 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return array of array<string,\Aternos\HangarApi\Model\VersionStats>|array<string,\Aternos\HangarApi\Model\VersionStats>|array<string,\Aternos\HangarApi\Model\VersionStats>, HTTP status code, HTTP response headers (array of strings)
      */
-    public function showVersionStatsWithHttpInfo($author, $slug, $name, $from_date, $to_date, string $contentType = self::contentTypes['showVersionStats'][0])
+    public function showVersionStatsWithHttpInfo($slug, $name, $from_date, $to_date, string $contentType = self::contentTypes['showVersionStats'][0])
     {
-        $request = $this->showVersionStatsRequest($author, $slug, $name, $from_date, $to_date, $contentType);
+        $request = $this->showVersionStatsRequest($slug, $name, $from_date, $to_date, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1543,7 +4159,6 @@ class VersionsApi
      *
      * Returns the stats for a version
      *
-     * @param  string $author The author of the version to return the stats for (required)
      * @param  string $slug The slug of the project to return stats for (required)
      * @param  string $name The version to return the stats for (required)
      * @param  string $from_date The first date to include in the result (required)
@@ -1553,9 +4168,9 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function showVersionStatsAsync($author, $slug, $name, $from_date, $to_date, string $contentType = self::contentTypes['showVersionStats'][0])
+    public function showVersionStatsAsync($slug, $name, $from_date, $to_date, string $contentType = self::contentTypes['showVersionStats'][0])
     {
-        return $this->showVersionStatsAsyncWithHttpInfo($author, $slug, $name, $from_date, $to_date, $contentType)
+        return $this->showVersionStatsAsyncWithHttpInfo($slug, $name, $from_date, $to_date, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1568,7 +4183,6 @@ class VersionsApi
      *
      * Returns the stats for a version
      *
-     * @param  string $author The author of the version to return the stats for (required)
      * @param  string $slug The slug of the project to return stats for (required)
      * @param  string $name The version to return the stats for (required)
      * @param  string $from_date The first date to include in the result (required)
@@ -1578,10 +4192,10 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function showVersionStatsAsyncWithHttpInfo($author, $slug, $name, $from_date, $to_date, string $contentType = self::contentTypes['showVersionStats'][0])
+    public function showVersionStatsAsyncWithHttpInfo($slug, $name, $from_date, $to_date, string $contentType = self::contentTypes['showVersionStats'][0])
     {
         $returnType = 'array<string,\Aternos\HangarApi\Model\VersionStats>';
-        $request = $this->showVersionStatsRequest($author, $slug, $name, $from_date, $to_date, $contentType);
+        $request = $this->showVersionStatsRequest($slug, $name, $from_date, $to_date, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1622,7 +4236,6 @@ class VersionsApi
     /**
      * Create request for operation 'showVersionStats'
      *
-     * @param  string $author The author of the version to return the stats for (required)
      * @param  string $slug The slug of the project to return stats for (required)
      * @param  string $name The version to return the stats for (required)
      * @param  string $from_date The first date to include in the result (required)
@@ -1632,15 +4245,8 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function showVersionStatsRequest($author, $slug, $name, $from_date, $to_date, string $contentType = self::contentTypes['showVersionStats'][0])
+    public function showVersionStatsRequest($slug, $name, $from_date, $to_date, string $contentType = self::contentTypes['showVersionStats'][0])
     {
-
-        // verify the required parameter 'author' is set
-        if ($author === null || (is_array($author) && count($author) === 0)) {
-            throw new \InvalidArgumentException(
-                'Missing the required parameter $author when calling showVersionStats'
-            );
-        }
 
         // verify the required parameter 'slug' is set
         if ($slug === null || (is_array($slug) && count($slug) === 0)) {
@@ -1671,7 +4277,7 @@ class VersionsApi
         }
 
 
-        $resourcePath = '/api/v1/projects/{author}/{slug}/versions/{name}/stats';
+        $resourcePath = '/api/v1/projects/{slug}/versions/{name}/stats';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -1698,14 +4304,6 @@ class VersionsApi
         ) ?? []);
 
 
-        // path params
-        if ($author !== null) {
-            $resourcePath = str_replace(
-                '{' . 'author' . '}',
-                ObjectSerializer::toPathValue($author),
-                $resourcePath
-            );
-        }
         // path params
         if ($slug !== null) {
             $resourcePath = str_replace(
@@ -1786,7 +4384,6 @@ class VersionsApi
      *
      * Creates a new version and returns parts of its metadata
      *
-     * @param  string $author The author of the project to return versions for (required)
      * @param  string $slug The slug of the project to return versions for (required)
      * @param  \Aternos\HangarApi\Model\VersionUpload $version_upload version_upload (required)
      * @param  \SplFileObject[] $files The version files in order of selected platforms, if any (optional)
@@ -1796,9 +4393,9 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \Aternos\HangarApi\Model\UploadedVersion|\Aternos\HangarApi\Model\UploadedVersion|\Aternos\HangarApi\Model\UploadedVersion
      */
-    public function uploadVersion($author, $slug, $version_upload, $files = null, string $contentType = self::contentTypes['uploadVersion'][0])
+    public function uploadVersion($slug, $version_upload, $files = null, string $contentType = self::contentTypes['uploadVersion'][0])
     {
-        list($response) = $this->uploadVersionWithHttpInfo($author, $slug, $version_upload, $files, $contentType);
+        list($response) = $this->uploadVersionWithHttpInfo($slug, $version_upload, $files, $contentType);
         return $response;
     }
 
@@ -1807,7 +4404,6 @@ class VersionsApi
      *
      * Creates a new version and returns parts of its metadata
      *
-     * @param  string $author The author of the project to return versions for (required)
      * @param  string $slug The slug of the project to return versions for (required)
      * @param  \Aternos\HangarApi\Model\VersionUpload $version_upload (required)
      * @param  \SplFileObject[] $files The version files in order of selected platforms, if any (optional)
@@ -1817,9 +4413,9 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return array of \Aternos\HangarApi\Model\UploadedVersion|\Aternos\HangarApi\Model\UploadedVersion|\Aternos\HangarApi\Model\UploadedVersion, HTTP status code, HTTP response headers (array of strings)
      */
-    public function uploadVersionWithHttpInfo($author, $slug, $version_upload, $files = null, string $contentType = self::contentTypes['uploadVersion'][0])
+    public function uploadVersionWithHttpInfo($slug, $version_upload, $files = null, string $contentType = self::contentTypes['uploadVersion'][0])
     {
-        $request = $this->uploadVersionRequest($author, $slug, $version_upload, $files, $contentType);
+        $request = $this->uploadVersionRequest($slug, $version_upload, $files, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1956,7 +4552,6 @@ class VersionsApi
      *
      * Creates a new version and returns parts of its metadata
      *
-     * @param  string $author The author of the project to return versions for (required)
      * @param  string $slug The slug of the project to return versions for (required)
      * @param  \Aternos\HangarApi\Model\VersionUpload $version_upload (required)
      * @param  \SplFileObject[] $files The version files in order of selected platforms, if any (optional)
@@ -1965,9 +4560,9 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function uploadVersionAsync($author, $slug, $version_upload, $files = null, string $contentType = self::contentTypes['uploadVersion'][0])
+    public function uploadVersionAsync($slug, $version_upload, $files = null, string $contentType = self::contentTypes['uploadVersion'][0])
     {
-        return $this->uploadVersionAsyncWithHttpInfo($author, $slug, $version_upload, $files, $contentType)
+        return $this->uploadVersionAsyncWithHttpInfo($slug, $version_upload, $files, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1980,7 +4575,6 @@ class VersionsApi
      *
      * Creates a new version and returns parts of its metadata
      *
-     * @param  string $author The author of the project to return versions for (required)
      * @param  string $slug The slug of the project to return versions for (required)
      * @param  \Aternos\HangarApi\Model\VersionUpload $version_upload (required)
      * @param  \SplFileObject[] $files The version files in order of selected platforms, if any (optional)
@@ -1989,10 +4583,10 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function uploadVersionAsyncWithHttpInfo($author, $slug, $version_upload, $files = null, string $contentType = self::contentTypes['uploadVersion'][0])
+    public function uploadVersionAsyncWithHttpInfo($slug, $version_upload, $files = null, string $contentType = self::contentTypes['uploadVersion'][0])
     {
         $returnType = '\Aternos\HangarApi\Model\UploadedVersion';
-        $request = $this->uploadVersionRequest($author, $slug, $version_upload, $files, $contentType);
+        $request = $this->uploadVersionRequest($slug, $version_upload, $files, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -2033,7 +4627,6 @@ class VersionsApi
     /**
      * Create request for operation 'uploadVersion'
      *
-     * @param  string $author The author of the project to return versions for (required)
      * @param  string $slug The slug of the project to return versions for (required)
      * @param  \Aternos\HangarApi\Model\VersionUpload $version_upload (required)
      * @param  \SplFileObject[] $files The version files in order of selected platforms, if any (optional)
@@ -2042,15 +4635,8 @@ class VersionsApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function uploadVersionRequest($author, $slug, $version_upload, $files = null, string $contentType = self::contentTypes['uploadVersion'][0])
+    public function uploadVersionRequest($slug, $version_upload, $files = null, string $contentType = self::contentTypes['uploadVersion'][0])
     {
-
-        // verify the required parameter 'author' is set
-        if ($author === null || (is_array($author) && count($author) === 0)) {
-            throw new \InvalidArgumentException(
-                'Missing the required parameter $author when calling uploadVersion'
-            );
-        }
 
         // verify the required parameter 'slug' is set
         if ($slug === null || (is_array($slug) && count($slug) === 0)) {
@@ -2063,6 +4649,336 @@ class VersionsApi
         if ($version_upload === null || (is_array($version_upload) && count($version_upload) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $version_upload when calling uploadVersion'
+            );
+        }
+
+
+
+        $resourcePath = '/api/v1/projects/{slug}/upload';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+
+
+        // path params
+        if ($slug !== null) {
+            $resourcePath = str_replace(
+                '{' . 'slug' . '}',
+                ObjectSerializer::toPathValue($slug),
+                $resourcePath
+            );
+        }
+
+        // form params
+        if ($files !== null) {
+            $multipart = true;
+            $formParams['files'] = [];
+            $paramFiles = is_array($files) ? $files : [$files];
+            foreach ($paramFiles as $paramFile) {
+                $formParams['files'][] = \GuzzleHttp\Psr7\Utils::tryFopen(
+                    ObjectSerializer::toFormValue($paramFile),
+                    'rb'
+                );
+            }
+        }
+        // form params
+        if ($version_upload !== null) {
+            $formParams['versionUpload'] = ObjectSerializer::toFormValue($version_upload);
+        }
+
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/json', ],
+            $contentType,
+            $multipart
+        );
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
+                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = ObjectSerializer::buildQuery($formParams);
+            }
+        }
+
+        // this endpoint requires Bearer (JWT) authentication (access token)
+        if (!empty($this->config->getAccessToken())) {
+            $headers['Authorization'] = 'Bearer ' . $this->config->getAccessToken();
+        }
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $operationHost = $this->config->getHost();
+        $query = ObjectSerializer::buildQuery($queryParams);
+        return new Request(
+            'POST',
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Operation uploadVersion1
+     *
+     * @param  string $author The author of the project to return versions for (required)
+     * @param  string $slug The slug of the project to return versions for (required)
+     * @param  \Aternos\HangarApi\Model\VersionUpload $version_upload version_upload (required)
+     * @param  \SplFileObject[] $files The version files in order of selected platforms, if any (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadVersion1'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return \Aternos\HangarApi\Model\UploadedVersion
+     * @deprecated
+     */
+    public function uploadVersion1($author, $slug, $version_upload, $files = null, string $contentType = self::contentTypes['uploadVersion1'][0])
+    {
+        list($response) = $this->uploadVersion1WithHttpInfo($author, $slug, $version_upload, $files, $contentType);
+        return $response;
+    }
+
+    /**
+     * Operation uploadVersion1WithHttpInfo
+     *
+     * @param  string $author The author of the project to return versions for (required)
+     * @param  string $slug The slug of the project to return versions for (required)
+     * @param  \Aternos\HangarApi\Model\VersionUpload $version_upload (required)
+     * @param  \SplFileObject[] $files The version files in order of selected platforms, if any (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadVersion1'] to see the possible values for this operation
+     *
+     * @throws \Aternos\HangarApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of \Aternos\HangarApi\Model\UploadedVersion, HTTP status code, HTTP response headers (array of strings)
+     * @deprecated
+     */
+    public function uploadVersion1WithHttpInfo($author, $slug, $version_upload, $files = null, string $contentType = self::contentTypes['uploadVersion1'][0])
+    {
+        $request = $this->uploadVersion1Request($author, $slug, $version_upload, $files, $contentType);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                );
+            } catch (ConnectException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    null,
+                    null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        (string) $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    (string) $response->getBody()
+                );
+            }
+
+            switch($statusCode) {
+                case 200:
+                    if ('\Aternos\HangarApi\Model\UploadedVersion' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('\Aternos\HangarApi\Model\UploadedVersion' !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\Aternos\HangarApi\Model\UploadedVersion', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+            $returnType = '\Aternos\HangarApi\Model\UploadedVersion';
+            if ($returnType === '\SplFileObject') {
+                $content = $response->getBody(); //stream goes to serializer
+            } else {
+                $content = (string) $response->getBody();
+                if ($returnType !== 'string') {
+                    $content = json_decode($content);
+                }
+            }
+
+            return [
+                ObjectSerializer::deserialize($content, $returnType, []),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            ];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\Aternos\HangarApi\Model\UploadedVersion',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation uploadVersion1Async
+     *
+     * @param  string $author The author of the project to return versions for (required)
+     * @param  string $slug The slug of the project to return versions for (required)
+     * @param  \Aternos\HangarApi\Model\VersionUpload $version_upload (required)
+     * @param  \SplFileObject[] $files The version files in order of selected platforms, if any (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadVersion1'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @deprecated
+     */
+    public function uploadVersion1Async($author, $slug, $version_upload, $files = null, string $contentType = self::contentTypes['uploadVersion1'][0])
+    {
+        return $this->uploadVersion1AsyncWithHttpInfo($author, $slug, $version_upload, $files, $contentType)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation uploadVersion1AsyncWithHttpInfo
+     *
+     * @param  string $author The author of the project to return versions for (required)
+     * @param  string $slug The slug of the project to return versions for (required)
+     * @param  \Aternos\HangarApi\Model\VersionUpload $version_upload (required)
+     * @param  \SplFileObject[] $files The version files in order of selected platforms, if any (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadVersion1'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @deprecated
+     */
+    public function uploadVersion1AsyncWithHttpInfo($author, $slug, $version_upload, $files = null, string $contentType = self::contentTypes['uploadVersion1'][0])
+    {
+        $returnType = '\Aternos\HangarApi\Model\UploadedVersion';
+        $request = $this->uploadVersion1Request($author, $slug, $version_upload, $files, $contentType);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    if ($returnType === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ($returnType !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'uploadVersion1'
+     *
+     * @param  string $author The author of the project to return versions for (required)
+     * @param  string $slug The slug of the project to return versions for (required)
+     * @param  \Aternos\HangarApi\Model\VersionUpload $version_upload (required)
+     * @param  \SplFileObject[] $files The version files in order of selected platforms, if any (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadVersion1'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     * @deprecated
+     */
+    public function uploadVersion1Request($author, $slug, $version_upload, $files = null, string $contentType = self::contentTypes['uploadVersion1'][0])
+    {
+
+        // verify the required parameter 'author' is set
+        if ($author === null || (is_array($author) && count($author) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $author when calling uploadVersion1'
+            );
+        }
+
+        // verify the required parameter 'slug' is set
+        if ($slug === null || (is_array($slug) && count($slug) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $slug when calling uploadVersion1'
+            );
+        }
+
+        // verify the required parameter 'version_upload' is set
+        if ($version_upload === null || (is_array($version_upload) && count($version_upload) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $version_upload when calling uploadVersion1'
             );
         }
 
@@ -2142,10 +5058,6 @@ class VersionsApi
             }
         }
 
-        // this endpoint requires Bearer (JWT) authentication (access token)
-        if (!empty($this->config->getAccessToken())) {
-            $headers['Authorization'] = 'Bearer ' . $this->config->getAccessToken();
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {

--- a/lib/Client/CompactProject.php
+++ b/lib/Client/CompactProject.php
@@ -22,7 +22,7 @@ class CompactProject
 {
     public function __construct(
         protected HangarAPIClient $client,
-        protected ProjectCompact $project,
+        protected ProjectCompact  $project,
     )
     {
     }
@@ -42,7 +42,7 @@ class CompactProject
      */
     public function getProject(): Project
     {
-        return $this->client->getProject($this->project->getNamespace()->getOwner(), $this->project->getNamespace()->getSlug());
+        return $this->client->getProject($this->project->getNamespace()->getSlug());
     }
 
     /**
@@ -94,7 +94,6 @@ class CompactProject
     public function getDailyStats(?DateTime $from = null, ?DateTime $to = null): array
     {
         return $this->client->getDailyProjectStats(
-            $this->project->getNamespace()->getOwner(),
             $this->project->getNamespace()->getSlug(),
             $from ?? $this->getData()->getCreatedAt(),
             $to
@@ -138,10 +137,7 @@ class CompactProject
      */
     public function getMainPage(): ProjectPage
     {
-        return $this->client->getProjectMainPage(
-            $this->project->getNamespace()->getOwner(),
-            $this->project->getNamespace()->getSlug(),
-        );
+        return $this->client->getProjectMainPage($this->project->getNamespace()->getSlug());
     }
 
     /**
@@ -152,10 +148,6 @@ class CompactProject
      */
     public function getPage(string $path): ProjectPage
     {
-        return $this->client->getProjectPage(
-            $this->project->getNamespace()->getOwner(),
-            $this->project->getNamespace()->getSlug(),
-            $path,
-        );
+        return $this->client->getProjectPage($this->project->getNamespace()->getSlug(), $path);
     }
 }

--- a/lib/Client/HangarAPIClient.php
+++ b/lib/Client/HangarAPIClient.php
@@ -477,13 +477,13 @@ class HangarAPIClient
      * Get a list of hangar staff
      *
      * Requires the view_public_info permission
-     * @param string $query Search query
+     * @param string $query Search query. Default: "" (all)
      * @param RequestPagination|null $pagination
      * @param string|null $sort Optional name of the field to sort the results by
      * @return StaffList
      * @throws ApiException
      */
-    public function getStaff(string $query, ?RequestPagination $pagination = null, ?string $sort = null): StaffList
+    public function getStaff(string $query = "", ?RequestPagination $pagination = null, ?string $sort = null): StaffList
     {
         $this->authenticate();
 
@@ -507,13 +507,13 @@ class HangarAPIClient
 
     /**
      * Search the API for project authors matching the search query
-     * @param string $query Search query
+     * @param string $query Search query. Default: "" (all)
      * @param RequestPagination|null $pagination
      * @param string|null $sort Optional name of the field to sort the results by
      * @return AuthorList
      * @throws ApiException
      */
-    public function getAuthors(string $query, ?RequestPagination $pagination = null, ?string $sort = null): AuthorList
+    public function getAuthors(string $query = "", ?RequestPagination $pagination = null, ?string $sort = null): AuthorList
     {
         $this->authenticate();
 

--- a/lib/Client/HangarAPIClient.php
+++ b/lib/Client/HangarAPIClient.php
@@ -63,7 +63,7 @@ class HangarAPIClient
     public function __construct(Configuration $configuration = null)
     {
         $this->setConfiguration($configuration ?? (new Configuration())
-            ->setUserAgent("php-hangar-api/1.0.0"));
+            ->setUserAgent("php-hangar-api/2.0.0"));
     }
 
     /**

--- a/lib/Client/HangarAPIClient.php
+++ b/lib/Client/HangarAPIClient.php
@@ -19,7 +19,6 @@ use Aternos\HangarApi\Client\List\User\ProjectStarGazersList;
 use Aternos\HangarApi\Client\List\User\ProjectWatcherList;
 use Aternos\HangarApi\Client\List\User\StaffList;
 use Aternos\HangarApi\Client\List\UserList;
-use Aternos\HangarApi\Client\Options\Platform;
 use Aternos\HangarApi\Client\Options\ProjectSearch\ProjectSearchOptions;
 use Aternos\HangarApi\Client\Options\UserSearch\UserSearchOptions;
 use Aternos\HangarApi\Client\Options\VersionSearch\VersionSearchOptions;
@@ -129,34 +128,32 @@ class HangarAPIClient
     }
 
     /**
-     * Check if the user has all the given permissions
+     * Check if the user has all the given permissions for a project
      * @param string[] $permissions (value of {@see NamedPermission})
-     * @param string|null $owner
      * @param string|null $project
      * @return bool
      * @throws ApiException
      */
-    public function hasPermissions(array $permissions, ?string $owner = null, ?string $project = null): bool
+    public function hasPermissions(array $permissions, ?string $project = null): bool
     {
         if (!$this->authenticate()) {
             return sizeof($permissions) === 0 || sizeof($permissions) === 1 &&
                 $permissions[0] === NamedPermission::VIEW_PUBLIC_INFO;
         }
 
-        return $this->permissions->hasAll($permissions, $owner, $project)->getResult();
+        return $this->permissions->hasAll($permissions, $project)->getResult();
     }
 
     /**
      * Check if the user has a specific permission
      * @param string $permission (value of {@see NamedPermission})
-     * @param string|null $owner
      * @param string|null $project
      * @return bool
      * @throws ApiException
      */
-    public function hasPermission(string $permission, ?string $owner = null, ?string $project = null): bool
+    public function hasPermission(string $permission, ?string $project = null): bool
     {
-        return $this->hasPermissions([$permission], $owner, $project);
+        return $this->hasPermissions([$permission], $project);
     }
 
     /**
@@ -186,16 +183,15 @@ class HangarAPIClient
 
     /**
      * Get a single project
-     * @param string $author
-     * @param string $name
+     * @param string $slug
      * @return Project
      * @throws ApiException
      */
-    public function getProject(string $author, string $name): Project
+    public function getProject(string $slug): Project
     {
         $this->authenticate();
 
-        $result = $this->projects->getProject($author, $name);
+        $result = $this->projects->getProject($slug);
         return new Project($this, $result);
     }
 
@@ -214,7 +210,7 @@ class HangarAPIClient
             ->setOffset(0)
             ->setLimit(25);
 
-        $result = $this->projects->getProjectWatchers($namespace->getOwner(), $namespace->getSlug(), $pagination);
+        $result = $this->projects->getProjectWatchers($namespace->getSlug(), $pagination);
         return new ProjectWatcherList(
             $this,
             $result,
@@ -228,25 +224,23 @@ class HangarAPIClient
      * Days without downloads/views will not be included
      *
      * Requires the is_subject_member permission
-     * @param string $owner
      * @param string $slug
      * @param DateTime $from
      * @param DateTime|null $to default: now
      * @return array<string, DayProjectStats>
      * @throws ApiException
      */
-    public function getDailyProjectStats(string $owner, string $slug, DateTime $from, ?DateTime $to = null): array
+    public function getDailyProjectStats(string $slug, DateTime $from, ?DateTime $to = null): array
     {
         $this->authenticate();
 
-        if (!$this->hasPermission(NamedPermission::IS_SUBJECT_MEMBER, $owner, $slug)) {
+        if (!$this->hasPermission(NamedPermission::IS_SUBJECT_MEMBER, $slug)) {
             throw new ApiException('You need the is_subject_member permission to view project statistics');
         }
 
         $to ??= new DateTime();
 
         return $this->projects->showProjectStats(
-            $owner,
             $slug,
             $from->format(DateTimeInterface::RFC3339),
             $to->format(DateTimeInterface::RFC3339)
@@ -268,7 +262,7 @@ class HangarAPIClient
             ->setOffset(0)
             ->setLimit(25);
 
-        $result = $this->projects->getProjectStarGazers($namespace->getOwner(), $namespace->getSlug(), $pagination);
+        $result = $this->projects->getProjectStarGazers($namespace->getSlug(), $pagination);
         return new ProjectStarGazersList(
             $this,
             $result,
@@ -292,7 +286,7 @@ class HangarAPIClient
             ->setOffset(0)
             ->setLimit(25);
 
-        $result = $this->projects->getProjectMembers($namespace->getOwner(), $namespace->getSlug(), $pagination);
+        $result = $this->projects->getProjectMembers($namespace->getSlug(), $pagination);
         return new ProjectMemberList($this, $result, $namespace, $pagination);
     }
 
@@ -317,7 +311,6 @@ class HangarAPIClient
         }
 
         $result = $this->versions->listVersions(
-            $options->getProjectNamespace()->getOwner(),
             $options->getProjectNamespace()->getSlug(),
             $options->getPagination(),
             $options->getChannel(),
@@ -340,7 +333,7 @@ class HangarAPIClient
         $this->authenticate();
 
         $namespace = $project instanceof Project ? $project->getData()->getNamespace() : $project;
-        $result = $this->versions->showVersion($namespace->getOwner(), $namespace->getSlug(), $name);
+        $result = $this->versions->showVersion($namespace->getSlug(), $name);
         return new Version(
             $this,
             $result,
@@ -360,25 +353,17 @@ class HangarAPIClient
      * @return array<string, VersionStats>
      * @throws ApiException
      */
-    public function getDailyProjectVersionStats(
-        Version   $version,
-        DateTime $from,
-        ?DateTime $to = null
-    ): array
+    public function getDailyProjectVersionStats(Version $version, DateTime $from, ?DateTime $to = null): array
     {
         $this->authenticate();
 
-        if (!$this->hasPermission(
-            NamedPermission::IS_SUBJECT_MEMBER,
-            $version->getProjectNamespace()->getOwner(),
-            $version->getProjectNamespace()->getSlug())) {
+        if (!$this->hasPermission(NamedPermission::IS_SUBJECT_MEMBER, $version->getProjectNamespace()->getSlug())) {
             throw new ApiException('You need the is_subject_member permission to view version statistics');
         }
 
         $to ??= new DateTime();
 
         return $this->versions->showVersionStats(
-            $version->getProjectNamespace()->getOwner(),
             $version->getProjectNamespace()->getSlug(),
             $version->getData()->getName(),
             $from->format(DateTimeInterface::RFC3339),
@@ -492,11 +477,13 @@ class HangarAPIClient
      * Get a list of hangar staff
      *
      * Requires the view_public_info permission
+     * @param string $query Search query
      * @param RequestPagination|null $pagination
+     * @param string|null $sort Optional name of the field to sort the results by
      * @return StaffList
      * @throws ApiException
      */
-    public function getStaff(?RequestPagination $pagination = null): StaffList
+    public function getStaff(string $query, ?RequestPagination $pagination = null, ?string $sort = null): StaffList
     {
         $this->authenticate();
 
@@ -508,21 +495,25 @@ class HangarAPIClient
             ->setOffset(0)
             ->setLimit(25);
 
-        $result = $this->users->getStaff($pagination);
+        $result = $this->users->getStaff($query, $pagination, $sort);
         return new StaffList(
             $this,
             $result,
             $pagination,
+            $query,
+            $sort
         );
     }
 
     /**
-     * Get the authors of a project
+     * Search the API for project authors matching the search query
+     * @param string $query Search query
      * @param RequestPagination|null $pagination
+     * @param string|null $sort Optional name of the field to sort the results by
      * @return AuthorList
      * @throws ApiException
      */
-    public function getAuthors(?RequestPagination $pagination = null): AuthorList
+    public function getAuthors(string $query, ?RequestPagination $pagination = null, ?string $sort = null): AuthorList
     {
         $this->authenticate();
 
@@ -530,11 +521,13 @@ class HangarAPIClient
             ->setOffset(0)
             ->setLimit(25);
 
-        $result = $this->users->getAuthors($pagination);
+        $result = $this->users->getAuthors($query, $pagination);
         return new AuthorList(
             $this,
             $result,
             $pagination,
+            $query,
+            $sort
         );
     }
 
@@ -542,24 +535,22 @@ class HangarAPIClient
      * Get the main page of a project
      *
      * Requires the view_public_info permission
-     * @param string $author
      * @param string $slug
      * @return ProjectPage
      * @throws ApiException
      */
-    public function getProjectMainPage(string $author, string $slug): ProjectPage
+    public function getProjectMainPage(string $slug): ProjectPage
     {
         $this->authenticate();
 
-        if (!$this->hasPermission(NamedPermission::VIEW_PUBLIC_INFO, $author, $slug)) {
+        if (!$this->hasPermission(NamedPermission::VIEW_PUBLIC_INFO, $slug)) {
             throw new ApiException('You need the view_public_info permission to view project pages');
         }
 
         return new ProjectPage(
             $this,
-            $author,
             $slug,
-            $this->pages->getMainPage($author, $slug),
+            $this->pages->getMainPage($slug),
         );
     }
 
@@ -569,25 +560,23 @@ class HangarAPIClient
      * Calling this with an empty path is equivalent to calling getProjectMainPage
      *
      * Requires the view_public_info permission
-     * @param string $author
      * @param string $slug
      * @param string $path
      * @return ProjectPage
      * @throws ApiException
      */
-    public function getProjectPage(string $author, string $slug, string $path): ProjectPage
+    public function getProjectPage(string $slug, string $path): ProjectPage
     {
         $this->authenticate();
 
-        if (!$this->hasPermission(NamedPermission::VIEW_PUBLIC_INFO, $author, $slug)) {
+        if (!$this->hasPermission(NamedPermission::VIEW_PUBLIC_INFO, $slug)) {
             throw new ApiException('You need the view_public_info permission to view project pages');
         }
 
         return new ProjectPage(
             $this,
-            $author,
             $slug,
-            $this->pages->getPage($author, $slug, $path),
+            $this->pages->getPage($slug, $path),
         );
     }
 
@@ -595,27 +584,25 @@ class HangarAPIClient
      * Edit the main page of a project
      *
      * Requires the edit_page permission
-     * @param string $author
      * @param string $slug
      * @param string $content
      * @return ProjectPage
      * @throws ApiException
      */
-    public function editProjectMainPage(string $author, string $slug, string $content): ProjectPage
+    public function editProjectMainPage(string $slug, string $content): ProjectPage
     {
         $this->authenticate();
 
-        if (!$this->hasPermission(NamedPermission::EDIT_PAGE, $author, $slug)) {
+        if (!$this->hasPermission(NamedPermission::EDIT_PAGE, $slug)) {
             throw new ApiException('You need the edit_page permission to edit project pages');
         }
 
         $form = new StringContent();
         $form->setContent($content);
-        $this->pages->editMainPage($author, $slug, $form);
+        $this->pages->editMainPage($slug, $form);
 
         return new ProjectPage(
             $this,
-            $author,
             $slug,
             $content,
         );
@@ -626,29 +613,27 @@ class HangarAPIClient
      * Starting and trailing slashes are ignored by the Hangar API
      *
      * Requires the edit_page permission
-     * @param string $author
      * @param string $slug
      * @param string $path
      * @param string $content
      * @return ProjectPage
      * @throws ApiException
      */
-    public function editProjectPage(string $author, string $slug, string $path, string $content): ProjectPage
+    public function editProjectPage(string $slug, string $path, string $content): ProjectPage
     {
         $this->authenticate();
 
-        if (!$this->hasPermission(NamedPermission::EDIT_PAGE, $author, $slug)) {
+        if (!$this->hasPermission(NamedPermission::EDIT_PAGE, $slug)) {
             throw new ApiException('You need the edit_page permission to edit project pages');
         }
 
         $form = new PageEditForm();
         $form->setContent($content);
         $form->setPath($path);
-        $this->pages->editPage($author, $slug, $form);
+        $this->pages->editPage($slug, $form);
 
         return new ProjectPage(
             $this,
-            $author,
             $slug,
             $content,
             $path,

--- a/lib/Client/List/QueryableAndSortableUserList.php
+++ b/lib/Client/List/QueryableAndSortableUserList.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Aternos\HangarApi\Client\List;
+
+use Aternos\HangarApi\Client\HangarAPIClient;
+use Aternos\HangarApi\Model\PaginatedResultUser;
+use Aternos\HangarApi\Model\RequestPagination;
+
+/**
+ * This class enhances the UserList and gives it the ability to be queried and sorted.
+ * The search query parameter is required and the sort parameter is optional.
+ *
+ * @package Aternos\HangarApi\Client\List
+ * @description A queryable and paginated list of users
+ * @extends UserList
+ */
+class QueryableAndSortableUserList extends UserList
+{
+
+    public function __construct(
+        HangarAPIClient $client,
+        PaginatedResultUser $result,
+        protected RequestPagination $requestPagination,
+        protected string $query,
+        protected ?string $sort = null,
+    )
+    {
+        parent::__construct($client, $result, null);
+    }
+
+}

--- a/lib/Client/List/User/AuthorList.php
+++ b/lib/Client/List/User/AuthorList.php
@@ -2,10 +2,7 @@
 
 namespace Aternos\HangarApi\Client\List\User;
 
-use Aternos\HangarApi\Client\HangarAPIClient;
-use Aternos\HangarApi\Client\List\UserList;
-use Aternos\HangarApi\Model\PaginatedResultUser;
-use Aternos\HangarApi\Model\RequestPagination;
+use Aternos\HangarApi\Client\List\QueryableAndSortableUserList;
 
 /**
  * Class AuthorList
@@ -13,17 +10,12 @@ use Aternos\HangarApi\Model\RequestPagination;
  * @package Aternos\HangarApi\Client\List\User
  * @description A paginated list of authors (users that own at least one project)
  */
-class AuthorList extends UserList
+class AuthorList extends QueryableAndSortableUserList
 {
-    public function __construct(HangarAPIClient $client, PaginatedResultUser $result, protected RequestPagination $requestPagination)
-    {
-        parent::__construct($client, $result, null);
-    }
-
     public function getOffset(int $offset): static
     {
         $pagination = clone $this->requestPagination;
         $pagination->setOffset($offset);
-        return $this->client->getAuthors($pagination);
+        return $this->client->getAuthors($this->query, $pagination, $this->sort);
     }
 }

--- a/lib/Client/List/User/StaffList.php
+++ b/lib/Client/List/User/StaffList.php
@@ -2,10 +2,7 @@
 
 namespace Aternos\HangarApi\Client\List\User;
 
-use Aternos\HangarApi\Client\HangarAPIClient;
-use Aternos\HangarApi\Client\List\UserList;
-use Aternos\HangarApi\Model\PaginatedResultUser;
-use Aternos\HangarApi\Model\RequestPagination;
+use Aternos\HangarApi\Client\List\QueryableAndSortableUserList;
 
 /**
  * Class StaffList
@@ -13,17 +10,12 @@ use Aternos\HangarApi\Model\RequestPagination;
  * @package Aternos\HangarApi\Client\List\User
  * @description A paginated list of staff members
  */
-class StaffList extends UserList
+class StaffList extends QueryableAndSortableUserList
 {
-    public function __construct(HangarAPIClient $client, PaginatedResultUser $result, protected RequestPagination $requestPagination)
-    {
-        parent::__construct($client, $result, null);
-    }
-
     public function getOffset(int $offset): static
     {
         $pagination = clone $this->requestPagination;
         $pagination->setOffset($offset);
-        return $this->client->getStaff($pagination);
+        return $this->client->getStaff($this->query, $pagination, $this->sort);
     }
 }

--- a/lib/Client/Project.php
+++ b/lib/Client/Project.php
@@ -20,7 +20,7 @@ use DateTime;
 class Project
 {
     public function __construct(
-        protected HangarAPIClient $client,
+        protected HangarAPIClient                  $client,
         protected \Aternos\HangarApi\Model\Project $project,
     )
     {
@@ -84,7 +84,6 @@ class Project
     public function getDailyStats(?DateTime $from = null, ?DateTime $to = null): array
     {
         return $this->client->getDailyProjectStats(
-            $this->project->getNamespace()->getOwner(),
             $this->project->getNamespace()->getSlug(),
             $from ?? $this->getData()->getCreatedAt(),
             $to
@@ -128,10 +127,7 @@ class Project
      */
     public function getMainPage(): ProjectPage
     {
-        return $this->client->getProjectMainPage(
-            $this->project->getNamespace()->getOwner(),
-            $this->project->getNamespace()->getSlug(),
-        );
+        return $this->client->getProjectMainPage($this->project->getNamespace()->getSlug());
     }
 
     /**
@@ -142,10 +138,6 @@ class Project
      */
     public function getPage(string $path): ProjectPage
     {
-        return $this->client->getProjectPage(
-            $this->project->getNamespace()->getOwner(),
-            $this->project->getNamespace()->getSlug(),
-            $path,
-        );
+        return $this->client->getProjectPage($this->project->getNamespace()->getSlug(), $path);
     }
 }

--- a/lib/Client/ProjectPage.php
+++ b/lib/Client/ProjectPage.php
@@ -10,7 +10,6 @@ class ProjectPage
 
     public function __construct(
         protected HangarAPIClient $client,
-        protected string $owner,
         protected string $slug,
         protected string $content,
         protected string $path = "",
@@ -46,7 +45,7 @@ class ProjectPage
      */
     public function getProject(): Project
     {
-        return $this->project ??= $this->client->getProject($this->owner, $this->slug);
+        return $this->project ??= $this->client->getProject($this->slug);
     }
 
     /**
@@ -87,7 +86,7 @@ class ProjectPage
      */
     public function save(): static
     {
-        $this->client->editProjectPage($this->owner, $this->slug, $this->path, $this->content);
+        $this->client->editProjectPage($this->slug, $this->path, $this->content);
         return $this;
     }
 }

--- a/lib/Client/Version.php
+++ b/lib/Client/Version.php
@@ -3,7 +3,6 @@
 namespace Aternos\HangarApi\Client;
 
 use Aternos\HangarApi\ApiException;
-use Aternos\HangarApi\Client\Options\Platform;
 use Aternos\HangarApi\Model\ProjectNamespace;
 use Aternos\HangarApi\Model\VersionStats;
 use DateTime;
@@ -44,7 +43,7 @@ class Version
             return $this->project;
         }
 
-        $this->project = $this->client->getProject($this->projectNamespace->getOwner(), $this->projectNamespace->getSlug());
+        $this->project = $this->client->getProject($this->projectNamespace->getSlug());
         return $this->project;
     }
 

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -100,7 +100,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'OpenAPI-Generator/1.0.0/PHP';
+    protected $userAgent = 'OpenAPI-Generator/2.0.0/PHP';
 
     /**
      * Debug switch (default set to false)
@@ -433,7 +433,7 @@ class Configuration
         $report .= '    OS: ' . php_uname() . PHP_EOL;
         $report .= '    PHP Version: ' . PHP_VERSION . PHP_EOL;
         $report .= '    The version of the OpenAPI document: 1.0' . PHP_EOL;
-        $report .= '    SDK Package Version: 1.0.0' . PHP_EOL;
+        $report .= '    SDK Package Version: 2.0.0' . PHP_EOL;
         $report .= '    Temp Folder Path: ' . self::getDefaultConfiguration()->getTempFolderPath() . PHP_EOL;
 
         return $report;

--- a/lib/Model/ApiSession.php
+++ b/lib/Model/ApiSession.php
@@ -309,7 +309,7 @@ class ApiSession implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets token
      *
-     * @param string|null $token token
+     * @param string|null $token JWT used for authentication
      *
      * @return self
      */
@@ -336,7 +336,7 @@ class ApiSession implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets expires_in
      *
-     * @param int|null $expires_in expires_in
+     * @param int|null $expires_in Milliseconds this JWT expires in
      *
      * @return self
      */

--- a/lib/Model/Category.php
+++ b/lib/Model/Category.php
@@ -33,6 +33,7 @@ use \Aternos\HangarApi\ObjectSerializer;
  * Category Class Doc Comment
  *
  * @category Class
+ * @description The category of the project
  * @package  Aternos\HangarApi
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech

--- a/lib/Model/ChannelFlag.php
+++ b/lib/Model/ChannelFlag.php
@@ -48,6 +48,8 @@ class ChannelFlag
 
     public const PINNED = 'PINNED';
 
+    public const SENDS_NOTIFICATIONS = 'SENDS_NOTIFICATIONS';
+
     /**
      * Gets allowable values of the enum
      * @return string[]
@@ -57,7 +59,8 @@ class ChannelFlag
         return [
             self::FROZEN,
             self::UNSTABLE,
-            self::PINNED
+            self::PINNED,
+            self::SENDS_NOTIFICATIONS
         ];
     }
 }

--- a/lib/Model/LinkSection.php
+++ b/lib/Model/LinkSection.php
@@ -356,7 +356,7 @@ class LinkSection implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets type
      *
-     * @param string $type type
+     * @param string $type Type of the link. Either SIDEBAR or TOP
      *
      * @return self
      */

--- a/lib/Model/NamedPermission.php
+++ b/lib/Model/NamedPermission.php
@@ -27,7 +27,6 @@
  */
 
 namespace Aternos\HangarApi\Model;
-use \Aternos\HangarApi\ObjectSerializer;
 
 /**
  * NamedPermission Class Doc Comment
@@ -104,8 +103,6 @@ class NamedPermission
 
     public const EDIT_ALL_USER_SETTINGS = 'edit_all_user_settings';
 
-    public const SEE_IP_ADDRESSES = 'see_ip_addresses';
-
     /**
      * Gets allowable values of the enum
      * @return string[]
@@ -143,8 +140,7 @@ class NamedPermission
             self::RESTORE_PROJECT,
             self::HARD_DELETE_PROJECT,
             self::HARD_DELETE_VERSION,
-            self::EDIT_ALL_USER_SETTINGS,
-            self::SEE_IP_ADDRESSES
+            self::EDIT_ALL_USER_SETTINGS
         ];
     }
 }

--- a/lib/Model/Platform.php
+++ b/lib/Model/Platform.php
@@ -33,6 +33,7 @@ use \Aternos\HangarApi\ObjectSerializer;
  * Platform Class Doc Comment
  *
  * @category Class
+ * @description Server platform
  * @package  Aternos\HangarApi
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech

--- a/lib/Model/PlatformVersionDownload.php
+++ b/lib/Model/PlatformVersionDownload.php
@@ -343,7 +343,7 @@ class PlatformVersionDownload implements ModelInterface, ArrayAccess, \JsonSeria
     /**
      * Sets external_url
      *
-     * @param string|null $external_url external_url
+     * @param string|null $external_url External download url if not directly uploaded to Hangar
      *
      * @return self
      */
@@ -370,7 +370,7 @@ class PlatformVersionDownload implements ModelInterface, ArrayAccess, \JsonSeria
     /**
      * Sets download_url
      *
-     * @param string|null $download_url download_url
+     * @param string|null $download_url Hangar download url if not an external download
      *
      * @return self
      */

--- a/lib/Model/PluginDependency.php
+++ b/lib/Model/PluginDependency.php
@@ -35,6 +35,7 @@ use \Aternos\HangarApi\ObjectSerializer;
  * PluginDependency Class Doc Comment
  *
  * @category Class
+ * @description Map of each platform&#39;s plugin dependencies
  * @package  Aternos\HangarApi
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
@@ -59,8 +60,8 @@ class PluginDependency implements ModelInterface, ArrayAccess, \JsonSerializable
     protected static $openAPITypes = [
         'name' => 'string',
         'required' => 'bool',
-        'namespace' => '\Aternos\HangarApi\Model\ProjectNamespace',
-        'external_url' => 'string'
+        'external_url' => 'string',
+        'platform' => '\Aternos\HangarApi\Model\Platform'
     ];
 
     /**
@@ -73,8 +74,8 @@ class PluginDependency implements ModelInterface, ArrayAccess, \JsonSerializable
     protected static $openAPIFormats = [
         'name' => null,
         'required' => null,
-        'namespace' => null,
-        'external_url' => null
+        'external_url' => null,
+        'platform' => null
     ];
 
     /**
@@ -85,8 +86,8 @@ class PluginDependency implements ModelInterface, ArrayAccess, \JsonSerializable
     protected static array $openAPINullables = [
         'name' => false,
 		'required' => false,
-		'namespace' => false,
-		'external_url' => false
+		'external_url' => false,
+		'platform' => false
     ];
 
     /**
@@ -177,8 +178,8 @@ class PluginDependency implements ModelInterface, ArrayAccess, \JsonSerializable
     protected static $attributeMap = [
         'name' => 'name',
         'required' => 'required',
-        'namespace' => 'namespace',
-        'external_url' => 'externalUrl'
+        'external_url' => 'externalUrl',
+        'platform' => 'platform'
     ];
 
     /**
@@ -189,8 +190,8 @@ class PluginDependency implements ModelInterface, ArrayAccess, \JsonSerializable
     protected static $setters = [
         'name' => 'setName',
         'required' => 'setRequired',
-        'namespace' => 'setNamespace',
-        'external_url' => 'setExternalUrl'
+        'external_url' => 'setExternalUrl',
+        'platform' => 'setPlatform'
     ];
 
     /**
@@ -201,8 +202,8 @@ class PluginDependency implements ModelInterface, ArrayAccess, \JsonSerializable
     protected static $getters = [
         'name' => 'getName',
         'required' => 'getRequired',
-        'namespace' => 'getNamespace',
-        'external_url' => 'getExternalUrl'
+        'external_url' => 'getExternalUrl',
+        'platform' => 'getPlatform'
     ];
 
     /**
@@ -264,8 +265,8 @@ class PluginDependency implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $this->setIfExists('name', $data ?? [], null);
         $this->setIfExists('required', $data ?? [], null);
-        $this->setIfExists('namespace', $data ?? [], null);
         $this->setIfExists('external_url', $data ?? [], null);
+        $this->setIfExists('platform', $data ?? [], null);
     }
 
     /**
@@ -323,7 +324,7 @@ class PluginDependency implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets name
      *
-     * @param string|null $name name
+     * @param string|null $name Name of the plugin dependency. For non-external dependencies, this should be the Hangar project name
      *
      * @return self
      */
@@ -350,7 +351,7 @@ class PluginDependency implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets required
      *
-     * @param bool|null $required required
+     * @param bool|null $required Whether the dependency is required for the plugin to function
      *
      * @return self
      */
@@ -360,33 +361,6 @@ class PluginDependency implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable required cannot be null');
         }
         $this->container['required'] = $required;
-
-        return $this;
-    }
-
-    /**
-     * Gets namespace
-     *
-     * @return \Aternos\HangarApi\Model\ProjectNamespace|null
-     */
-    public function getNamespace()
-    {
-        return $this->container['namespace'];
-    }
-
-    /**
-     * Sets namespace
-     *
-     * @param \Aternos\HangarApi\Model\ProjectNamespace|null $namespace namespace
-     *
-     * @return self
-     */
-    public function setNamespace($namespace)
-    {
-        if (is_null($namespace)) {
-            throw new \InvalidArgumentException('non-nullable namespace cannot be null');
-        }
-        $this->container['namespace'] = $namespace;
 
         return $this;
     }
@@ -404,7 +378,7 @@ class PluginDependency implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets external_url
      *
-     * @param string|null $external_url external_url
+     * @param string|null $external_url External url to download the dependency from if not a Hangar project, else null
      *
      * @return self
      */
@@ -414,6 +388,33 @@ class PluginDependency implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable external_url cannot be null');
         }
         $this->container['external_url'] = $external_url;
+
+        return $this;
+    }
+
+    /**
+     * Gets platform
+     *
+     * @return \Aternos\HangarApi\Model\Platform|null
+     */
+    public function getPlatform()
+    {
+        return $this->container['platform'];
+    }
+
+    /**
+     * Sets platform
+     *
+     * @param \Aternos\HangarApi\Model\Platform|null $platform platform
+     *
+     * @return self
+     */
+    public function setPlatform($platform)
+    {
+        if (is_null($platform)) {
+            throw new \InvalidArgumentException('non-nullable platform cannot be null');
+        }
+        $this->container['platform'] = $platform;
 
         return $this;
     }

--- a/lib/Model/Project.php
+++ b/lib/Model/Project.php
@@ -399,7 +399,7 @@ class Project implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets name
      *
-     * @param string|null $name name
+     * @param string|null $name The unique name of the project
      *
      * @return self
      */
@@ -507,7 +507,7 @@ class Project implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets last_updated
      *
-     * @param \DateTime|null $last_updated last_updated
+     * @param \DateTime|null $last_updated The last time the project was updated
      *
      * @return self
      */
@@ -561,7 +561,7 @@ class Project implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets avatar_url
      *
-     * @param string|null $avatar_url avatar_url
+     * @param string|null $avatar_url The url to the project's icon
      *
      * @return self
      */
@@ -588,7 +588,7 @@ class Project implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets description
      *
-     * @param string|null $description description
+     * @param string|null $description The short description of the project
      *
      * @return self
      */

--- a/lib/Model/ProjectChannel.php
+++ b/lib/Model/ProjectChannel.php
@@ -59,6 +59,7 @@ class ProjectChannel implements ModelInterface, ArrayAccess, \JsonSerializable
     protected static $openAPITypes = [
         'created_at' => '\DateTime',
         'name' => 'string',
+        'description' => 'string',
         'color' => '\Aternos\HangarApi\Model\Color',
         'flags' => '\Aternos\HangarApi\Model\ChannelFlag[]'
     ];
@@ -73,6 +74,7 @@ class ProjectChannel implements ModelInterface, ArrayAccess, \JsonSerializable
     protected static $openAPIFormats = [
         'created_at' => 'date-time',
         'name' => null,
+        'description' => null,
         'color' => null,
         'flags' => null
     ];
@@ -85,6 +87,7 @@ class ProjectChannel implements ModelInterface, ArrayAccess, \JsonSerializable
     protected static array $openAPINullables = [
         'created_at' => false,
 		'name' => false,
+		'description' => false,
 		'color' => false,
 		'flags' => false
     ];
@@ -177,6 +180,7 @@ class ProjectChannel implements ModelInterface, ArrayAccess, \JsonSerializable
     protected static $attributeMap = [
         'created_at' => 'createdAt',
         'name' => 'name',
+        'description' => 'description',
         'color' => 'color',
         'flags' => 'flags'
     ];
@@ -189,6 +193,7 @@ class ProjectChannel implements ModelInterface, ArrayAccess, \JsonSerializable
     protected static $setters = [
         'created_at' => 'setCreatedAt',
         'name' => 'setName',
+        'description' => 'setDescription',
         'color' => 'setColor',
         'flags' => 'setFlags'
     ];
@@ -201,6 +206,7 @@ class ProjectChannel implements ModelInterface, ArrayAccess, \JsonSerializable
     protected static $getters = [
         'created_at' => 'getCreatedAt',
         'name' => 'getName',
+        'description' => 'getDescription',
         'color' => 'getColor',
         'flags' => 'getFlags'
     ];
@@ -264,6 +270,7 @@ class ProjectChannel implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $this->setIfExists('created_at', $data ?? [], null);
         $this->setIfExists('name', $data ?? [], null);
+        $this->setIfExists('description', $data ?? [], null);
         $this->setIfExists('color', $data ?? [], null);
         $this->setIfExists('flags', $data ?? [], null);
     }
@@ -360,6 +367,33 @@ class ProjectChannel implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable name cannot be null');
         }
         $this->container['name'] = $name;
+
+        return $this;
+    }
+
+    /**
+     * Gets description
+     *
+     * @return string|null
+     */
+    public function getDescription()
+    {
+        return $this->container['description'];
+    }
+
+    /**
+     * Sets description
+     *
+     * @param string|null $description description
+     *
+     * @return self
+     */
+    public function setDescription($description)
+    {
+        if (is_null($description)) {
+            throw new \InvalidArgumentException('non-nullable description cannot be null');
+        }
+        $this->container['description'] = $description;
 
         return $this;
     }

--- a/lib/Model/ProjectCompact.php
+++ b/lib/Model/ProjectCompact.php
@@ -378,7 +378,7 @@ class ProjectCompact implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets name
      *
-     * @param string|null $name name
+     * @param string|null $name The unique name of the project
      *
      * @return self
      */
@@ -486,7 +486,7 @@ class ProjectCompact implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets last_updated
      *
-     * @param \DateTime|null $last_updated last_updated
+     * @param \DateTime|null $last_updated The last time the project was updated
      *
      * @return self
      */
@@ -540,7 +540,7 @@ class ProjectCompact implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets avatar_url
      *
-     * @param string|null $avatar_url avatar_url
+     * @param string|null $avatar_url The url to the project's icon
      *
      * @return self
      */

--- a/lib/Model/ProjectNamespace.php
+++ b/lib/Model/ProjectNamespace.php
@@ -35,6 +35,7 @@ use \Aternos\HangarApi\ObjectSerializer;
  * ProjectNamespace Class Doc Comment
  *
  * @category Class
+ * @description The namespace of the project
  * @package  Aternos\HangarApi
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
@@ -336,7 +337,7 @@ class ProjectNamespace implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets slug
      *
-     * @param string|null $slug slug
+     * @param string|null $slug The unique name of a project
      *
      * @return self
      */

--- a/lib/Model/ProjectSettings.php
+++ b/lib/Model/ProjectSettings.php
@@ -35,6 +35,7 @@ use \Aternos\HangarApi\ObjectSerializer;
  * ProjectSettings Class Doc Comment
  *
  * @category Class
+ * @description The settings of the project
  * @package  Aternos\HangarApi
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech

--- a/lib/Model/ProjectSortingStrategy.php
+++ b/lib/Model/ProjectSortingStrategy.php
@@ -52,8 +52,6 @@ class ProjectSortingStrategy
 
     public const UPDATED = 'updated';
 
-    public const ONLY_RELEVANCE = 'only_relevance';
-
     public const RECENT_VIEWS = 'recent_views';
 
     public const RECENT_DOWNLOADS = 'recent_downloads';
@@ -70,7 +68,6 @@ class ProjectSortingStrategy
             self::VIEWS,
             self::NEWEST,
             self::UPDATED,
-            self::ONLY_RELEVANCE,
             self::RECENT_VIEWS,
             self::RECENT_DOWNLOADS
         ];

--- a/lib/Model/ProjectStats.php
+++ b/lib/Model/ProjectStats.php
@@ -35,6 +35,7 @@ use \Aternos\HangarApi\ObjectSerializer;
  * ProjectStats Class Doc Comment
  *
  * @category Class
+ * @description Stats of the project
  * @package  Aternos\HangarApi
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech

--- a/lib/Model/StringContent.php
+++ b/lib/Model/StringContent.php
@@ -306,7 +306,7 @@ class StringContent implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets content
      *
-     * @param string $content content
+     * @param string $content A non-null, non-empty string
      *
      * @return self
      */

--- a/lib/Model/UploadedVersion.php
+++ b/lib/Model/UploadedVersion.php
@@ -35,6 +35,7 @@ use \Aternos\HangarApi\ObjectSerializer;
  * UploadedVersion Class Doc Comment
  *
  * @category Class
+ * @description A version that has been uploaded
  * @package  Aternos\HangarApi
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
@@ -302,7 +303,7 @@ class UploadedVersion implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets url
      *
-     * @param string|null $url url
+     * @param string|null $url URL of the uploaded version
      *
      * @return self
      */

--- a/lib/Model/UserActions.php
+++ b/lib/Model/UserActions.php
@@ -35,6 +35,7 @@ use \Aternos\HangarApi\ObjectSerializer;
  * UserActions Class Doc Comment
  *
  * @category Class
+ * @description Information about your interactions with the project
  * @package  Aternos\HangarApi
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech

--- a/lib/Model/Visibility.php
+++ b/lib/Model/Visibility.php
@@ -27,12 +27,12 @@
  */
 
 namespace Aternos\HangarApi\Model;
-use \Aternos\HangarApi\ObjectSerializer;
 
 /**
  * Visibility Class Doc Comment
  *
  * @category Class
+ * @description The visibility of a project or version
  * @package  Aternos\HangarApi
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech

--- a/test/Client/ClientTest.php
+++ b/test/Client/ClientTest.php
@@ -7,6 +7,7 @@ use Aternos\HangarApi\Client\HangarAPIClient;
 use Aternos\HangarApi\Client\List\ResultList;
 use Aternos\HangarApi\Client\Options\ProjectCategory;
 use Aternos\HangarApi\Client\Options\ProjectSearch\ProjectSearchOptions;
+use Aternos\HangarApi\Model\ProjectNamespace;
 use Aternos\HangarApi\Model\RequestPagination;
 use PHPUnit\Framework\TestCase;
 
@@ -49,7 +50,7 @@ class ClientTest extends TestCase
     protected function assertValidNamespace($namespace): void
     {
         $this->assertNotNull($namespace);
-        $this->assertInstanceOf(\Aternos\HangarApi\Model\ProjectNamespace::class, $namespace);
+        $this->assertInstanceOf(ProjectNamespace::class, $namespace);
         $this->assertNotNull($namespace->getOwner());
         $this->assertNotNull($namespace->getSlug());
     }
@@ -246,7 +247,7 @@ class ClientTest extends TestCase
      */
     public function testGetProject()
     {
-        $project = $this->apiClient->getProject("Aternos", "mclogs");
+        $project = $this->apiClient->getProject("mclogs");
         $this->assertNotNull($project);
         $this->assertValidProject($project);
         $this->assertEquals("Aternos", $project->getData()->getNamespace()->getOwner());
@@ -267,7 +268,7 @@ class ClientTest extends TestCase
      */
     public function testGetProjectMembers()
     {
-        $project = $this->apiClient->getProject("Aternos", "motdgg");
+        $project = $this->apiClient->getProject("motdgg");
         $this->assertNotNull($project);
         $this->assertValidProject($project);
         $this->assertEquals("Aternos", $project->getData()->getNamespace()->getOwner());
@@ -285,7 +286,7 @@ class ClientTest extends TestCase
      */
     public function testGetProjectWatchers()
     {
-        $project = $this->apiClient->getProject("Aternos", "motdgg");
+        $project = $this->apiClient->getProject("motdgg");
         $this->assertNotNull($project);
         $this->assertValidProject($project);
         $this->assertEquals("Aternos", $project->getData()->getNamespace()->getOwner());
@@ -321,7 +322,7 @@ class ClientTest extends TestCase
             $this->markTestSkipped("This test requires authentication.");
         }
 
-        $project = $this->apiClient->getProject("Aternos", "mclogs");
+        $project = $this->apiClient->getProject("mclogs");
         $this->assertNotNull($project);
         $this->assertValidProject($project);
 
@@ -348,7 +349,7 @@ class ClientTest extends TestCase
             $this->markTestSkipped("This test requires authentication.");
         }
 
-        $project = $this->apiClient->getProject("Aternos", "mclogs");
+        $project = $this->apiClient->getProject("mclogs");
         $this->assertNotNull($project);
         $this->assertValidProject($project);
 
@@ -471,7 +472,7 @@ class ClientTest extends TestCase
     public function testGetStaff()
     {
         $pagination = (new RequestPagination())->setLimit(1);
-        $users = $this->apiClient->getStaff($pagination);
+        $users = $this->apiClient->getStaff("",$pagination);
         $this->assertFalse($users->hasPreviousPage());
 
         $firstUserOfPage = [];
@@ -513,7 +514,7 @@ class ClientTest extends TestCase
     public function testGetAuthors()
     {
         $pagination = (new RequestPagination())->setLimit(10);
-        $users = $this->apiClient->getAuthors($pagination);
+        $users = $this->apiClient->getAuthors("", $pagination);
         $this->assertFalse($users->hasPreviousPage());
 
         $firstUserOfPage = [];
@@ -554,7 +555,7 @@ class ClientTest extends TestCase
      */
     public function testGetProjectPage()
     {
-        $page = $this->apiClient->getProjectMainPage("Aternos", "mclogs");
+        $page = $this->apiClient->getProjectMainPage("mclogs");
         $this->assertNotNull($page);
         $this->assertNotNull($page->getContent());
         $this->assertNotEmpty($page->getContent());

--- a/test/Client/ClientTest.php
+++ b/test/Client/ClientTest.php
@@ -29,7 +29,7 @@ class ClientTest extends TestCase
     public function setUp(): void
     {
         $this->apiClient = new HangarAPIClient();
-        $this->apiClient->setUserAgent("aternos/php-hangar-api@1.0.0 (contact@aternos.org)");
+        $this->apiClient->setUserAgent("aternos/php-hangar-api@2.0.0 (contact@aternos.org)");
         $this->apiClient->setApiKey(getenv("HANGAR_API_KEY"));
     }
 


### PR DESCRIPTION
A few days ago Hangar released some API changes.

From their [discord server](https://discord.gg/zvrAEbvJ4a):

> There are two important changes to the Hangar API: 
Firstly, all API routes previously containing author/slug should now be accessed just by its unique slug (e.g. api/v1/projects/{author}/{slug}/upload becomes api/v1/projects/{slug}/upload). This is to simplify getting and looking up projects by making project names unique. 
In the `projects/{slug}/upload API route, plugin dependencies should no longer include a namespace field for Hangar projects, but instead always use the name field for the now unique project name.
> 
> An actual break was done to the /projects endpoint, which had its searchWithRelevance parameter removed since it was not a really good metric as opposed to just sorting by stars, (recent) downloads, or (recent) views. By default, queries will now have the project with an exact name match as the first result, which you can toggle with the new prioritizeExactMatch parameter.
> 
> Otherwise, the old routes will continue to work where possible and simply redirect to the new ones, but you should still move away from the old as soon as you can. This should hopefully be the last large change to the API before a full release. :hatching_chick:


This results in the following changes:

### Changes in the generated code

**General**
 - Remove the author parameter and only use the slug in many APIs

**ChannelFlag**
 - Added `SENDS_NOTIFICATIONS`

**NamedPermission**
 - Removed `SEE_IP_ADDRESSES`

**PluginDependency**
 - Removed namespace property
 - Added platform property

**ProjectChannel**
 - Add description property

**ProjectsApi**
 - getProjects(): Replace parameter
                    `bool $order_with_relevance Whether projects should be sorted by the relevance to the given query (optional, default to true)`
                  with
                    `bool $prioritize_exact_match Whether to prioritize the project with an exact name match if present (optional, default to true)` See https://hangar.papermc.io/api-docs#/Projects/getProjects for more info

**ProjectSortingStrategy**
 - Removed `ONLY_RELEVANCE`

**UsersApi**
 - Add parameter `query` (search query) to methods `getAuthors()` and `getStaff()` to search for an user

**VersionsApi**
 - Remove author and only use slug
 - Deprecated old endpoints:
    - getVersions (/api/v1/projects/{author}/{slug}/versions)
    - getVersion (/api/v1/projects/{author}/{slug}/versions/{name})
    - downloadVersion -> renamed to downloadVersion1 (/api/v1/projects/{author}/{slug}/versions/{name}/{platform}/download)
    - getVersionStats (/api/v1/projects/{author}/{slug}/versions/{name}/stats)
    - getLatestReleaseVersion (/api/v1/projects/{author}/{slug}/latestrelease)
    - getLatestVersion (/api/v1/projects/{author}/{slug}/latest)
    - uploadVersion (/api/v1/projects/{author}/{slug}/upload)
 - New endpoints: 
    - uploadVersion (/api/v1/projects/{slug}/upload)
    - getLatestReleaseVersion (/api/v1/projects/{slug}/latestrelease)
    - getLatestVersion (/api/v1/projects/{slug}/latest)
    - getVersion (/api/v1/projects/{slug}/versions/{name})
    - getVersionStats (/api/v1/projects/{slug}/versions/{name}/stats)
    - getVersions (/api/v1/projects/{slug}/versions)
    - latestReleaseVersion
    - latestVersion


### Changes in our Client

**General**
 - Added the class `QueryableAndSortableUserList` that holds the properties `query` and `sort` and is used for staff and authors responses
 - Fixed all requests so that they do not use the author name any more and only use the slug

**HangerAPIClient**
 - getProject(): Removed parameter string $author
 - getProject(): Renamed parameter string $name to string $slug
 - getStaff(): Added parameter string $query, added parameter string|null $sort
 - getAuthors(): Added parameter string $query, added parameter string|null $sort
 - hasPermission(): Removed parameter ?string $owner
 - hasPermissions(): Removed parameter ?string $owner
 - getDailyProjectStats(): Removed parameter string $owner
 - editProjectPage(): Removed parameter string $author
 - getProjectMainPage(): Removed parameter string $author
 - getProjectPage(): Removed parameter string $author
 - editProjectMainPage(): Removed parameter string $author

**ProjectPage**
 - Removed property `protected string $owner`



I bumped the version to 2.0.0 because this PR contains some changes (like removing and adding some properties), although Hangar did not change its API version.

